### PR TITLE
Reduce test and build log noise

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -33,6 +33,9 @@ GitHub Actions runs the same baseline on push and pull request:
 - Root Jest is configured in `jest.config.js` and scans both `frontend` and `shared`.
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
+- Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
+- Frontend build output no longer logs repeated `NEXT_PUBLIC_API_URL configured: false` messages.
+- The Next.js custom font warning remains because `frontend/pages/_document.tsx` does not exist yet.
 
 ## Test Candidates
 
@@ -40,3 +43,4 @@ GitHub Actions runs the same baseline on push and pull request:
 - Add API client tests for token refresh and authorization header behavior.
 - Add backend auth utility tests for token creation and validation.
 - Add route/service tests for notes and auth error paths.
+- Add `frontend/pages/_document.tsx` and move global font links there, if the app keeps using link-based font loading.

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -4,7 +4,6 @@ import { getToken, setToken, removeToken } from '../../shared/utils/tokenUtils';
 import { API_ENDPOINTS } from '../../shared/constants/endpoints';
 
 const baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
-console.log('NEXT_PUBLIC_API_URL configured:', Boolean(process.env.NEXT_PUBLIC_API_URL));
 
 const apiClient = axios.create({
   baseURL,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,14 @@
 module.exports = {
   roots: ["<rootDir>/frontend", "<rootDir>/shared"],
   transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest",
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          esModuleInterop: true,
+        },
+      },
+    ],
   },
   testEnvironment: "jsdom",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],

--- a/shared/utils/calendarUtils.ts
+++ b/shared/utils/calendarUtils.ts
@@ -24,6 +24,5 @@ export const generateCalendarDates = (year: number, month: number) => {
       datesArray.push(null);
   }
 
-  console.log(datesArray); // デバッグ用に追加
   return datesArray;
 };


### PR DESCRIPTION
## Summary
- Removed debug output from `calendarUtils`
- Removed repeated build-time API URL config logging
- Suppressed the `ts-jest` `esModuleInterop` warning with minimal Jest config
- Updated verification docs with the current warning/noise baseline

## Verification
- `npm test` passed
  - 2 test suites passed
  - 5 tests passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `npm run build --prefix backend` passed

## Notes
- No dependency updates or audit fixes were included
- `package-lock.json` files were not changed
- Next.js custom font warning remains as a known follow-up
- Google Fonts stylesheet download warning remains as a known follow-up
- Backend build is still a placeholder