### PR TITLE
Add backend auth utils tests

### DIFF
--- a/backend/utils/__tests__/authUtils.spec.js
+++ b/backend/utils/__tests__/authUtils.spec.js
@@ -1,0 +1,148 @@
+/** @jest-environment node */
+
+jest.mock(
+  "jsonwebtoken",
+  () => ({
+    sign: jest.fn((payload, secret, options) =>
+      Buffer.from(JSON.stringify({ payload, secret, options })).toString("base64url")
+    ),
+    verify: jest.fn((token, secret) => {
+      try {
+        const decoded = JSON.parse(Buffer.from(token, "base64url").toString("utf8"));
+        if (decoded.secret !== secret) {
+          throw new Error("invalid signature");
+        }
+        return decoded.payload;
+      } catch (error) {
+        throw new Error("jwt malformed");
+      }
+    }),
+  }),
+  { virtual: true }
+);
+
+const jwt = require("jsonwebtoken");
+const {
+  validateEmail,
+  generateAccessToken,
+  generateRefreshToken,
+  verifyToken,
+  refreshAccessToken,
+} = require("../authUtils");
+
+const ORIGINAL_ENV = process.env;
+const TEST_SECRET = "test-secret";
+const TEST_USER = {
+  id: "user-123",
+  email: "user@example.com",
+};
+
+describe("authUtils", () => {
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      JWT_SECRET: TEST_SECRET,
+      ACCESS_TOKEN_EXPIRES: "1h",
+      REFRESH_TOKEN_EXPIRES: "7d",
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe("validateEmail", () => {
+    it("returns true for a valid email", () => {
+      expect(validateEmail("user@example.com")).toBe(true);
+    });
+
+    it("returns false for an invalid email", () => {
+      expect(validateEmail("user.example.com")).toBe(false);
+    });
+  });
+
+  describe("generateAccessToken", () => {
+    it("generates a verifiable access token with expected payload fields", () => {
+      const token = generateAccessToken(TEST_USER);
+      const decoded = jwt.verify(token, TEST_SECRET);
+
+      expect(decoded).toEqual(
+        expect.objectContaining({
+          id: TEST_USER.id,
+          email: TEST_USER.email,
+          sub: TEST_USER.id,
+          aud: "your-audience",
+        })
+      );
+    });
+
+    it("throws when JWT_SECRET is not configured", () => {
+      delete process.env.JWT_SECRET;
+
+      expect(() => generateAccessToken(TEST_USER)).toThrow("JWT_SECRETが設定されていません。");
+    });
+  });
+
+  describe("generateRefreshToken", () => {
+    it("generates a verifiable refresh token with expected payload fields", () => {
+      const token = generateRefreshToken(TEST_USER);
+      const decoded = jwt.verify(token, TEST_SECRET);
+
+      expect(decoded).toEqual(
+        expect.objectContaining({
+          id: TEST_USER.id,
+          email: TEST_USER.email,
+          sub: TEST_USER.id,
+          aud: "your-audience",
+        })
+      );
+    });
+  });
+
+  describe("verifyToken", () => {
+    it("returns the decoded payload for a valid token", async () => {
+      const token = generateAccessToken(TEST_USER);
+
+      await expect(verifyToken(token)).resolves.toEqual(
+        expect.objectContaining({
+          id: TEST_USER.id,
+          email: TEST_USER.email,
+          sub: TEST_USER.id,
+          aud: "your-audience",
+        })
+      );
+    });
+
+    it("returns null for an invalid token", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(verifyToken("invalid-token")).resolves.toBeNull();
+    });
+  });
+
+  describe("refreshAccessToken", () => {
+    it("returns a new valid access token for a valid refresh token", async () => {
+      const refreshToken = generateRefreshToken(TEST_USER);
+      const accessToken = await refreshAccessToken(refreshToken);
+      const decoded = jwt.verify(accessToken, TEST_SECRET);
+
+      expect(decoded).toEqual(
+        expect.objectContaining({
+          id: TEST_USER.id,
+          email: TEST_USER.email,
+          sub: TEST_USER.id,
+          aud: "your-audience",
+        })
+      );
+    });
+
+    it("throws for an invalid refresh token", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(refreshAccessToken("invalid-token")).rejects.toThrow(
+        "Invalid or expired refresh token"
+      );
+    });
+  });
+});

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -30,8 +30,9 @@ GitHub Actions runs the same baseline on push and pull request:
 
 - Frontend build is expected to pass once frontend dependencies are installed.
 - Backend build runs a JavaScript syntax check over backend `.js` files with `node --check`.
-- Root Jest is configured in `jest.config.js` and scans both `frontend` and `shared`.
+- Root Jest is configured in `jest.config.js` and scans `frontend`, `shared`, and `backend`.
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
+- Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
 - Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
 - Frontend build output no longer logs repeated `NEXT_PUBLIC_API_URL configured: false` messages.
@@ -41,7 +42,6 @@ GitHub Actions runs the same baseline on push and pull request:
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
 - Add API client tests for token refresh and authorization header behavior.
-- Add backend auth utility tests for token creation and validation.
 - Add route/service tests for notes and auth error paths.
 - Add `frontend/pages/_document.tsx` and move global font links there, if the app keeps using link-based font loading.
 - Add backend unit tests or integration tests; the current backend build checks syntax only.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  roots: ["<rootDir>/frontend", "<rootDir>/shared"],
+  roots: ["<rootDir>/frontend", "<rootDir>/shared", "<rootDir>/backend"],
   transform: {
     "^.+\\.(ts|tsx)$": [
       "ts-jest",
@@ -11,5 +11,6 @@ module.exports = {
     ],
   },
   testEnvironment: "jsdom",
+  modulePaths: ["<rootDir>/backend/node_modules"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 };


### PR DESCRIPTION
## Summary
- Added backend Jest coverage for `authUtils`
- Updated Jest roots to include `backend`
- Added tests for email validation, token generation, token verification, and refresh token handling
- Updated verification docs to reflect backend auth utility tests

## Verification
- `npm test` passed
  - 3 test suites passed
  - 14 tests passed
- `npm run build --prefix backend` passed
  - `Backend syntax check passed (11 files).`
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No dependency updates or audit fixes were included
- `package-lock.json` files were not changed
- `jsonwebtoken` is mocked in the unit test; real-library integration testing remains a future task
- Frontend custom font and Google Fonts warnings remain known follow-ups