### PR TITLE
Add backend note service tests

### DIFF
--- a/backend/services/__tests__/noteService.spec.js
+++ b/backend/services/__tests__/noteService.spec.js
@@ -1,0 +1,122 @@
+/** @jest-environment node */
+
+const verifyToken = jest.fn();
+const from = jest.fn();
+
+jest.mock("../../utils/authUtils", () => ({
+  verifyToken,
+}));
+
+jest.mock("../../utils/supabaseClient", () => ({
+  from,
+}));
+
+const { getNotes, createTag, getNotesByTags } = require("../noteService");
+
+const createResponse = () => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+describe("noteService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getNotes", () => {
+    it("returns 401 when Authorization token is missing", async () => {
+      const req = {
+        params: { date: "2024-06-01" },
+        headers: {},
+      };
+      const res = createResponse();
+
+      await getNotes(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "Authorization token missing" });
+      expect(verifyToken).not.toHaveBeenCalled();
+      expect(from).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when verifyToken returns null", async () => {
+      verifyToken.mockResolvedValue(null);
+      const req = {
+        params: { date: "2024-06-01" },
+        headers: { authorization: "Bearer invalid-token" },
+      };
+      const res = createResponse();
+
+      await getNotes(req, res);
+
+      expect(verifyToken).toHaveBeenCalledWith("invalid-token");
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "Invalid token" });
+      expect(from).not.toHaveBeenCalled();
+    });
+
+    it("returns notes for a valid token and successful Supabase query", async () => {
+      const notes = [{ id: 1, date: "2024-06-01", note: "Bench press" }];
+      const eqUserId = jest.fn().mockResolvedValue({ data: notes, error: null });
+      const eqDate = jest.fn(() => ({ eq: eqUserId }));
+      const select = jest.fn(() => ({ eq: eqDate }));
+      from.mockReturnValue({ select });
+      verifyToken.mockResolvedValue({ id: "user-123" });
+
+      const req = {
+        params: { date: "2024-06-01" },
+        headers: { authorization: "Bearer valid-token" },
+      };
+      const res = createResponse();
+
+      await getNotes(req, res);
+
+      expect(from).toHaveBeenCalledWith("notes");
+      expect(select).toHaveBeenCalledWith("*");
+      expect(eqDate).toHaveBeenCalledWith("date", "2024-06-01");
+      expect(eqUserId).toHaveBeenCalledWith("userid", "user-123");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ notes });
+    });
+  });
+
+  describe("createTag", () => {
+    it("returns 400 when tag is missing", async () => {
+      verifyToken.mockResolvedValue({ id: "user-123" });
+      const req = {
+        headers: { authorization: "Bearer valid-token" },
+        body: {},
+      };
+      const res = createResponse();
+
+      await createTag(req, res);
+
+      expect(verifyToken).toHaveBeenCalledWith("valid-token");
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: "Tag is required" });
+      expect(from).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getNotesByTags", () => {
+    it("returns an empty notes array when query.tags is missing", async () => {
+      verifyToken.mockResolvedValue({ id: "user-123" });
+      const req = {
+        headers: { authorization: "Bearer valid-token" },
+        query: {},
+      };
+      const res = createResponse();
+
+      await getNotesByTags(req, res);
+
+      expect(verifyToken).toHaveBeenCalledWith("valid-token");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ notes: [] });
+      expect(from).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -34,6 +34,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Frontend API client tests under `frontend/lib/__tests__` are included in `npm test` and CI.
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
+- Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
 - Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
 - Frontend build output no longer logs repeated `NEXT_PUBLIC_API_URL configured: false` messages.
@@ -43,6 +44,6 @@ GitHub Actions runs the same baseline on push and pull request:
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
 - Expand API client tests for retry limits and non-401 error paths.
-- Add route/service tests for notes and auth error paths.
+- Expand route/service tests for notes and auth error paths.
 - Add `frontend/pages/_document.tsx` and move global font links there, if the app keeps using link-based font loading.
 - Add backend unit tests or integration tests; the current backend build checks syntax only.


### PR DESCRIPTION
## Summary
- Added minimal unit tests for `noteService`
- Covered `getNotes` auth failures and Supabase success path
- Covered `createTag` missing tag validation
- Covered `getNotesByTags` missing tags query behavior
- Updated verification docs to include backend note service tests

## Verification
- `npm test` passed
  - 5 test suites passed
  - 25 tests passed
- `npm run build --prefix backend` passed
  - `Backend syntax check passed (12 files).`
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No dependency updates or audit fixes were included
- `package-lock.json` files were not changed
- Tests use mocked Supabase and mocked `verifyToken`
- Additional note service DB error paths remain future test candidates