### PR TITLE
Add backend auth service validation tests

### DIFF
--- a/backend/services/__tests__/authService.spec.js
+++ b/backend/services/__tests__/authService.spec.js
@@ -1,0 +1,191 @@
+/** @jest-environment node */
+
+const supabase = {
+  auth: {
+    signInWithPassword: jest.fn(),
+    signUp: jest.fn(),
+    setSession: jest.fn(),
+    updateUser: jest.fn(),
+    resetPasswordForEmail: jest.fn(),
+  },
+  from: jest.fn(),
+};
+
+const authUtils = {
+  verifyToken: jest.fn(),
+  generateAccessToken: jest.fn(),
+  generateRefreshToken: jest.fn(),
+};
+
+jest.mock("../../utils/supabaseClient", () => supabase);
+jest.mock("../../utils/authUtils", () => authUtils);
+jest.mock(
+  "validator",
+  () => ({
+    isEmail: jest.fn((value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)),
+    isLength: jest.fn((value, options) => value.length >= options.min),
+  }),
+  { virtual: true }
+);
+
+const {
+  handleLogin,
+  handleSignUp,
+  handleResetPassword,
+  handleForgotPassword,
+} = require("../authService");
+
+const createResponse = () => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+    cookie: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+const expectNoSupabaseAuthCalls = () => {
+  expect(supabase.auth.signInWithPassword).not.toHaveBeenCalled();
+  expect(supabase.auth.signUp).not.toHaveBeenCalled();
+  expect(supabase.auth.setSession).not.toHaveBeenCalled();
+  expect(supabase.auth.updateUser).not.toHaveBeenCalled();
+  expect(supabase.auth.resetPasswordForEmail).not.toHaveBeenCalled();
+};
+
+describe("authService validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("handleLogin", () => {
+    const cases = [
+      {
+        name: "email missing",
+        body: { password: "password123" },
+        expected: { error: "Email is required" },
+      },
+      {
+        name: "password missing",
+        body: { email: "user@example.com" },
+        expected: { error: "Password is required" },
+      },
+      {
+        name: "invalid email",
+        body: { email: "invalid-email", password: "password123" },
+        expected: { error: "Invalid email format" },
+      },
+      {
+        name: "short password",
+        body: { email: "user@example.com", password: "short" },
+        expected: { error: "Password must be at least 6 characters long" },
+      },
+    ];
+
+    it.each(cases)("returns 400 when $name", async ({ body, expected }) => {
+      const req = { body };
+      const res = createResponse();
+
+      await handleLogin(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expected);
+      expect(supabase.auth.signInWithPassword).not.toHaveBeenCalled();
+      expect(authUtils.generateAccessToken).not.toHaveBeenCalled();
+      expect(authUtils.generateRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleSignUp", () => {
+    const cases = [
+      {
+        name: "username missing",
+        body: { email: "user@example.com", password: "password123" },
+        expected: { error: "Username is required" },
+      },
+      {
+        name: "email missing",
+        body: { username: "user", password: "password123" },
+        expected: { error: "Email is required" },
+      },
+      {
+        name: "password missing",
+        body: { username: "user", email: "user@example.com" },
+        expected: { error: "Password is required" },
+      },
+      {
+        name: "invalid email",
+        body: { username: "user", email: "invalid-email", password: "password123" },
+        expected: { error: "Invalid email format" },
+      },
+      {
+        name: "short password",
+        body: { username: "user", email: "user@example.com", password: "short" },
+        expected: { error: "Password must be at least 6 characters long" },
+      },
+    ];
+
+    it.each(cases)("returns 400 when $name", async ({ body, expected }) => {
+      const req = { body };
+      const res = createResponse();
+
+      await handleSignUp(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expected);
+      expect(supabase.auth.signUp).not.toHaveBeenCalled();
+      expect(supabase.from).not.toHaveBeenCalled();
+      expect(authUtils.generateAccessToken).not.toHaveBeenCalled();
+      expect(authUtils.generateRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleResetPassword", () => {
+    const cases = [
+      {
+        name: "accessToken missing",
+        body: { newPassword: "password123" },
+        expected: { error: "Access token is missing" },
+      },
+      {
+        name: "newPassword missing",
+        body: { accessToken: "dummy-access-token" },
+        expected: { error: "New password is required" },
+      },
+      {
+        name: "short newPassword",
+        body: { accessToken: "dummy-access-token", newPassword: "short" },
+        expected: { error: "Password must be at least 6 characters long" },
+      },
+    ];
+
+    it.each(cases)("returns 400 when $name", async ({ body, expected }) => {
+      const req = { body };
+      const res = createResponse();
+
+      await handleResetPassword(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expected);
+      expect(supabase.auth.setSession).not.toHaveBeenCalled();
+      expect(supabase.auth.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleForgotPassword", () => {
+    it("returns 400 when email is missing", async () => {
+      const req = { body: {} };
+      const res = createResponse();
+
+      await handleForgotPassword(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: "Email is required" });
+      expect(supabase.auth.resetPasswordForEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not call Supabase auth for validation failures", () => {
+    expectNoSupabaseAuthCalls();
+  });
+});

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -35,6 +35,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
+- Backend auth service validation tests under `backend/services/__tests__` are included in `npm test` and CI.
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
 - Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
 - Frontend build output no longer logs repeated `NEXT_PUBLIC_API_URL configured: false` messages.
@@ -44,6 +45,6 @@ GitHub Actions runs the same baseline on push and pull request:
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
 - Expand API client tests for retry limits and non-401 error paths.
-- Expand route/service tests for notes and auth error paths.
+- Expand route/service tests for notes and auth Supabase success/error paths.
 - Add `frontend/pages/_document.tsx` and move global font links there, if the app keeps using link-based font loading.
 - Add backend unit tests or integration tests; the current backend build checks syntax only.


### PR DESCRIPTION
## Summary
- Added backend auth service validation tests
- Covered validation failures for login, sign up, reset password, and forgot password
- Verified validation failures do not call Supabase auth methods
- Updated verification docs to include auth service validation tests

## Verification
- `npm test` passed
  - 6 test suites passed
  - 39 tests passed
- `npm run build --prefix backend` passed
  - `Backend syntax check passed (13 files).`
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No dependency updates or audit fixes were included
- `package-lock.json` files were not changed
- Tests use mocked Supabase, mocked auth utilities, and mocked validator
- `handleRefresh` remains untested due to the existing async `verifyToken` handling concern
- Supabase success/error paths remain future test candidates