### PR TITLE
Fix auth refresh token verification

### DIFF
--- a/backend/services/__tests__/authService.spec.js
+++ b/backend/services/__tests__/authService.spec.js
@@ -31,6 +31,7 @@ jest.mock(
 const {
   handleLogin,
   handleSignUp,
+  handleRefresh,
   handleResetPassword,
   handleForgotPassword,
 } = require("../authService");
@@ -169,6 +170,62 @@ describe("authService validation", () => {
       expect(res.json).toHaveBeenCalledWith(expected);
       expect(supabase.auth.setSession).not.toHaveBeenCalled();
       expect(supabase.auth.updateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleRefresh", () => {
+    it("returns 401 when refreshToken cookie is missing", async () => {
+      const req = { cookies: {} };
+      const res = createResponse();
+
+      await handleRefresh(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "Refresh token is missing" });
+      expect(authUtils.verifyToken).not.toHaveBeenCalled();
+      expect(authUtils.generateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when verifyToken returns null", async () => {
+      authUtils.verifyToken.mockResolvedValue(null);
+      const req = { cookies: { refreshToken: "invalid-refresh-token" } };
+      const res = createResponse();
+
+      await handleRefresh(req, res);
+
+      expect(authUtils.verifyToken).toHaveBeenCalledWith("invalid-refresh-token");
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "Invalid or expired refresh token" });
+      expect(authUtils.generateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it("returns a new access token when verifyToken returns decoded user", async () => {
+      const decoded = { id: "user-123", email: "user@example.com" };
+      authUtils.verifyToken.mockResolvedValue(decoded);
+      authUtils.generateAccessToken.mockReturnValue("new-access-token");
+      const req = { cookies: { refreshToken: "valid-refresh-token" } };
+      const res = createResponse();
+
+      await handleRefresh(req, res);
+
+      expect(authUtils.verifyToken).toHaveBeenCalledWith("valid-refresh-token");
+      expect(authUtils.generateAccessToken).toHaveBeenCalledWith(decoded);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ access_token: "new-access-token" });
+    });
+
+    it("returns 500 when verifyToken rejects", async () => {
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      authUtils.verifyToken.mockRejectedValue(new Error("verify failed"));
+      const req = { cookies: { refreshToken: "broken-refresh-token" } };
+      const res = createResponse();
+
+      await handleRefresh(req, res);
+
+      expect(authUtils.verifyToken).toHaveBeenCalledWith("broken-refresh-token");
+      expect(authUtils.generateAccessToken).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: "Failed to refresh token" });
     });
   });
 

--- a/backend/services/authService.js
+++ b/backend/services/authService.js
@@ -55,7 +55,7 @@ const handleRefresh = async (req, res) => {
   }
 
   try {
-    const decoded = verifyToken(refreshToken);
+    const decoded = await verifyToken(refreshToken);
     if (!decoded) {
       return res.status(401).json({ error: "Invalid or expired refresh token" });
     }

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -35,7 +35,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
-- Backend auth service validation tests under `backend/services/__tests__` are included in `npm test` and CI.
+- Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
 - Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
 - Frontend build output no longer logs repeated `NEXT_PUBLIC_API_URL configured: false` messages.


### PR DESCRIPTION
## Summary
- Fixed `handleRefresh` to await async `verifyToken`
- Added refresh token unit tests for missing, invalid, valid, and verify failure cases
- Updated verification docs to mention auth refresh test coverage

## Verification
- `npm test` passed
  - 6 test suites passed
  - 43 tests passed
- `npm run build --prefix backend` passed
  - `Backend syntax check passed (13 files).`
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No dependency updates or audit fixes were included
- `package-lock.json` files were not changed
- API response shape and auth flow were not changed
- Supabase success/error paths remain future test candidates