### PR TITLE
Fix Next.js custom font warning

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -39,12 +39,12 @@ GitHub Actions runs the same baseline on push and pull request:
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
 - Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
 - Frontend build output no longer logs repeated `NEXT_PUBLIC_API_URL configured: false` messages.
-- The Next.js custom font warning remains because `frontend/pages/_document.tsx` does not exist yet.
+- The Next.js custom font warning is resolved by loading global font links in `frontend/pages/_document.tsx`.
 
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
-- Add `frontend/pages/_document.tsx` and move global font links there, if the app keeps using link-based font loading.
+- Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.
 - Add backend unit tests or integration tests; the current backend build checks syntax only.

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -19,13 +19,6 @@ function MyApp({ Component, pageProps }: AppProps) {
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
-          rel="stylesheet"
-        />
       </Head>
       <ChakraProvider theme={theme}>
         <AuthProvider>

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,0 +1,20 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- Moved global Google Fonts links from `_app.tsx` to `_document.tsx`
- Added standard Next.js Pages Router document structure
- Removed the Next.js custom font warning
- Updated verification docs

## Verification
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `npm test` passed
  - 6 test suites passed
  - 43 tests passed
- `npm run build --prefix backend` passed

## Notes
- No dependency updates or audit fixes were included
- `package-lock.json` files were not changed
- UI, theme, API, auth flow, and DB behavior were not changed
- Google Fonts download warning remains a known follow-up