### PR TITLE
Add workout set normalization utility

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -33,6 +33,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Root Jest is configured in `jest.config.js` and scans `frontend`, `shared`, and `backend`.
 - Frontend API client tests under `frontend/lib/__tests__` are included in `npm test` and CI.
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
+- Shared training normalization tests for `normalizeWorkoutSets` are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -44,6 +45,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
+- Add analytics utilities for estimated 1RM, volume load, weekly volume, and PR detection.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/normalizeWorkoutSets.spec.ts
+++ b/shared/utils/__tests__/normalizeWorkoutSets.spec.ts
@@ -1,0 +1,248 @@
+import { normalizeWorkoutSets, WorkoutNoteInput } from "../normalizeWorkoutSets";
+
+describe("normalizeWorkoutSets", () => {
+  it("returns an empty array for empty notes", () => {
+    expect(normalizeWorkoutSets([])).toEqual([]);
+  });
+
+  it("normalizes array exercises with multiple sets", () => {
+    const notes: WorkoutNoteInput[] = [
+      {
+        date: "2026-06-10",
+        userid: "user-1",
+        tags: ["push", "bench"],
+        exercises: [
+          {
+            exercise: "Bench Press",
+            note: "Paused reps",
+            sets: [
+              { weight: "100", reps: "5", rest: "180" },
+              { weight: 102.5, reps: 3, rest: null },
+            ],
+          },
+        ],
+      },
+    ];
+
+    expect(normalizeWorkoutSets(notes)).toEqual([
+      {
+        date: "2026-06-10",
+        userId: "user-1",
+        exerciseName: "Bench Press",
+        exerciseNote: "Paused reps",
+        setIndex: 0,
+        weight: 100,
+        reps: 5,
+        restSeconds: 180,
+        rpe: null,
+        rir: null,
+        failure: null,
+        tags: ["push", "bench"],
+      },
+      {
+        date: "2026-06-10",
+        userId: "user-1",
+        exerciseName: "Bench Press",
+        exerciseNote: "Paused reps",
+        setIndex: 1,
+        weight: 102.5,
+        reps: 3,
+        restSeconds: null,
+        rpe: null,
+        rir: null,
+        failure: null,
+        tags: ["push", "bench"],
+      },
+    ]);
+  });
+
+  it("parses exercises from a JSON string", () => {
+    const notes: WorkoutNoteInput[] = [
+      {
+        date: "2026-06-11",
+        exercises: JSON.stringify([
+          {
+            exercise: "Squat",
+            sets: [{ weight: "140", reps: "3", rest: "240" }],
+          },
+        ]),
+      },
+    ];
+
+    expect(normalizeWorkoutSets(notes)).toEqual([
+      {
+        date: "2026-06-11",
+        userId: null,
+        exerciseName: "Squat",
+        exerciseNote: null,
+        setIndex: 0,
+        weight: 140,
+        reps: 3,
+        restSeconds: 240,
+        rpe: null,
+        rir: null,
+        failure: null,
+        tags: [],
+      },
+    ]);
+  });
+
+  it("ignores invalid exercises JSON", () => {
+    expect(
+      normalizeWorkoutSets([
+        {
+          date: "2026-06-12",
+          exercises: "{invalid-json",
+        },
+      ])
+    ).toEqual([]);
+  });
+
+  it("converts invalid numeric values to null", () => {
+    const rows = normalizeWorkoutSets([
+      {
+        exercises: [
+          {
+            exercise: "Deadlift",
+            sets: [{ weight: "", reps: "abc", rest: undefined, rpe: null, rir: " " }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows[0]).toMatchObject({
+      weight: null,
+      reps: null,
+      restSeconds: null,
+      rpe: null,
+      rir: null,
+    });
+  });
+
+  it("skips exercises without set arrays", () => {
+    expect(
+      normalizeWorkoutSets([
+        {
+          exercises: [
+            { exercise: "Bench Press", sets: null },
+            { exercise: "Squat" },
+          ],
+        },
+      ])
+    ).toEqual([]);
+  });
+
+  it("preserves date, userId, exerciseName, exerciseNote, setIndex, and tags", () => {
+    const rows = normalizeWorkoutSets([
+      {
+        date: "2026-06-13",
+        userid: "user-2",
+        tags: ["legs"],
+        exercises: [
+          {
+            exercise: "Leg Press",
+            note: "Deep range",
+            sets: [
+              { weight: "200", reps: "10" },
+              { weight: "210", reps: "8" },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows.map(({ date, userId, exerciseName, exerciseNote, setIndex, tags }) => ({
+      date,
+      userId,
+      exerciseName,
+      exerciseNote,
+      setIndex,
+      tags,
+    }))).toEqual([
+      {
+        date: "2026-06-13",
+        userId: "user-2",
+        exerciseName: "Leg Press",
+        exerciseNote: "Deep range",
+        setIndex: 0,
+        tags: ["legs"],
+      },
+      {
+        date: "2026-06-13",
+        userId: "user-2",
+        exerciseName: "Leg Press",
+        exerciseNote: "Deep range",
+        setIndex: 1,
+        tags: ["legs"],
+      },
+    ]);
+  });
+
+  it("does not mutate original input", () => {
+    const notes: WorkoutNoteInput[] = [
+      {
+        date: "2026-06-14",
+        tags: ["pull"],
+        exercises: [
+          {
+            exercise: "Row",
+            sets: [{ weight: "80", reps: "10", rest: "90" }],
+          },
+        ],
+      },
+    ];
+    const original = JSON.stringify(notes);
+
+    normalizeWorkoutSets(notes);
+
+    expect(JSON.stringify(notes)).toBe(original);
+  });
+
+  it("normalizes optional rpe, rir, and failure values", () => {
+    expect(
+      normalizeWorkoutSets([
+        {
+          exercises: [
+            {
+              exercise: "",
+              note: null,
+              sets: [
+                { weight: "50", reps: "12", rpe: "8.5", rir: 1, failure: false },
+                { weight: "50", reps: "10", rpe: "abc", rir: "", failure: true },
+              ],
+            },
+          ],
+        },
+      ])
+    ).toEqual([
+      {
+        date: null,
+        userId: null,
+        exerciseName: "",
+        exerciseNote: null,
+        setIndex: 0,
+        weight: 50,
+        reps: 12,
+        restSeconds: null,
+        rpe: 8.5,
+        rir: 1,
+        failure: false,
+        tags: [],
+      },
+      {
+        date: null,
+        userId: null,
+        exerciseName: "",
+        exerciseNote: null,
+        setIndex: 1,
+        weight: 50,
+        reps: 10,
+        restSeconds: null,
+        rpe: null,
+        rir: null,
+        failure: true,
+        tags: [],
+      },
+    ]);
+  });
+});

--- a/shared/utils/normalizeWorkoutSets.ts
+++ b/shared/utils/normalizeWorkoutSets.ts
@@ -1,0 +1,103 @@
+export type WorkoutSetInput = {
+  weight?: string | number | null;
+  reps?: string | number | null;
+  rest?: string | number | null;
+  rpe?: string | number | null;
+  rir?: string | number | null;
+  failure?: boolean | null;
+};
+
+export type WorkoutExerciseInput = {
+  exercise?: string | null;
+  note?: string | null;
+  sets?: WorkoutSetInput[] | null;
+};
+
+export type WorkoutNoteInput = {
+  date?: string | null;
+  note?: string | null;
+  exercises?: WorkoutExerciseInput[] | string | null;
+  tags?: string[] | null;
+  userid?: string | null;
+};
+
+export type NormalizedWorkoutSet = {
+  date: string | null;
+  userId: string | null;
+  exerciseName: string;
+  exerciseNote: string | null;
+  setIndex: number;
+  weight: number | null;
+  reps: number | null;
+  restSeconds: number | null;
+  rpe: number | null;
+  rir: number | null;
+  failure: boolean | null;
+  tags: string[];
+};
+
+const safeNumber = (value: string | number | null | undefined): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseExercises = (
+  exercises: WorkoutNoteInput["exercises"]
+): WorkoutExerciseInput[] => {
+  if (Array.isArray(exercises)) {
+    return exercises;
+  }
+
+  if (typeof exercises !== "string") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(exercises);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const normalizeWorkoutSets = (
+  notes: WorkoutNoteInput[]
+): NormalizedWorkoutSet[] => {
+  if (!Array.isArray(notes) || notes.length === 0) {
+    return [];
+  }
+
+  return notes.flatMap((note) => {
+    const exercises = parseExercises(note.exercises);
+    const tags = Array.isArray(note.tags) ? [...note.tags] : [];
+
+    return exercises.flatMap((exercise) => {
+      if (!Array.isArray(exercise.sets)) {
+        return [];
+      }
+
+      return exercise.sets.map((set, setIndex) => ({
+        date: note.date ?? null,
+        userId: note.userid ?? null,
+        exerciseName: exercise.exercise ?? "",
+        exerciseNote: exercise.note ?? null,
+        setIndex,
+        weight: safeNumber(set.weight),
+        reps: safeNumber(set.reps),
+        restSeconds: safeNumber(set.rest),
+        rpe: safeNumber(set.rpe),
+        rir: safeNumber(set.rir),
+        failure: typeof set.failure === "boolean" ? set.failure : null,
+        tags,
+      }));
+    });
+  });
+};


### PR DESCRIPTION
## Summary
- Added a pure utility to normalize workout notes into set-level rows
- Supports array-based and JSON-string `exercises`
- Safely parses numeric fields such as weight, reps, rest, RPE, and RIR
- Preserves date, userId, exercise name, exercise note, set index, failure, and tags
- Added tests for normalization, invalid JSON, invalid numeric values, missing sets, immutability, and optional RPE/RIR/failure fields
- Updated verification docs

## Verification
- `npm test` passed
  - 7 test suites passed
  - 52 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Google Fonts download warning remains a known follow-up