### PR TITLE
Add training metrics utilities

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -34,6 +34,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Frontend API client tests under `frontend/lib/__tests__` are included in `npm test` and CI.
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
 - Shared training normalization tests for `normalizeWorkoutSets` are included in `npm test` and CI.
+- Shared training metrics tests for volume load and estimated 1RM are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -45,7 +46,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics utilities for estimated 1RM, volume load, weekly volume, and PR detection.
+- Add analytics utilities for weekly volume, PR detection, and BIG3 trend analysis.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/trainingMetrics.spec.ts
+++ b/shared/utils/__tests__/trainingMetrics.spec.ts
@@ -1,0 +1,102 @@
+import {
+  addTrainingMetricsToSet,
+  calculateEstimatedOneRepMax,
+  calculateVolumeLoad,
+} from "../trainingMetrics";
+import type { NormalizedWorkoutSet } from "../normalizeWorkoutSets";
+
+const baseSet: NormalizedWorkoutSet = {
+  date: "2026-06-11",
+  userId: "user-1",
+  exerciseName: "Bench Press",
+  exerciseNote: "Paused reps",
+  setIndex: 0,
+  weight: 100,
+  reps: 5,
+  restSeconds: 180,
+  rpe: null,
+  rir: null,
+  failure: null,
+  tags: ["push"],
+};
+
+describe("calculateVolumeLoad", () => {
+  it("calculates volume load for valid weight and reps", () => {
+    expect(calculateVolumeLoad(100, 5)).toBe(500);
+  });
+
+  it("allows decimal weight", () => {
+    expect(calculateVolumeLoad(102.5, 3)).toBe(307.5);
+  });
+
+  it("returns null for null weight or reps", () => {
+    expect(calculateVolumeLoad(null, 5)).toBeNull();
+    expect(calculateVolumeLoad(100, null)).toBeNull();
+  });
+
+  it("returns null for zero or negative values", () => {
+    expect(calculateVolumeLoad(100, 0)).toBeNull();
+    expect(calculateVolumeLoad(-100, 5)).toBeNull();
+    expect(calculateVolumeLoad(100, -5)).toBeNull();
+  });
+});
+
+describe("calculateEstimatedOneRepMax", () => {
+  it("returns weight for 1 rep", () => {
+    expect(calculateEstimatedOneRepMax(100, 1)).toBe(100);
+  });
+
+  it("calculates e1RM for 5 reps using the Epley formula", () => {
+    expect(calculateEstimatedOneRepMax(100, 5)).toBe(116.67);
+  });
+
+  it("calculates e1RM for 10 reps using the Epley formula", () => {
+    expect(calculateEstimatedOneRepMax(80, 10)).toBe(106.67);
+  });
+
+  it("returns null for reps greater than 12", () => {
+    expect(calculateEstimatedOneRepMax(60, 15)).toBeNull();
+  });
+
+  it("returns null for null, zero, or negative values", () => {
+    expect(calculateEstimatedOneRepMax(null, 5)).toBeNull();
+    expect(calculateEstimatedOneRepMax(100, null)).toBeNull();
+    expect(calculateEstimatedOneRepMax(100, 0)).toBeNull();
+    expect(calculateEstimatedOneRepMax(-100, 5)).toBeNull();
+    expect(calculateEstimatedOneRepMax(100, -5)).toBeNull();
+  });
+});
+
+describe("addTrainingMetricsToSet", () => {
+  it("adds metrics to a normalized workout set", () => {
+    expect(addTrainingMetricsToSet(baseSet)).toEqual({
+      ...baseSet,
+      tags: ["push"],
+      metrics: {
+        volumeLoad: 500,
+        estimatedOneRepMax: 116.67,
+      },
+    });
+  });
+
+  it("does not mutate the input set", () => {
+    const input = { ...baseSet, tags: [...baseSet.tags] };
+    const original = JSON.stringify(input);
+
+    const result = addTrainingMetricsToSet(input);
+    result.tags.push("mutated-result");
+
+    expect(JSON.stringify(input)).toBe(original);
+  });
+
+  it("returns null metrics when weight or reps is null", () => {
+    expect(addTrainingMetricsToSet({ ...baseSet, weight: null }).metrics).toEqual({
+      volumeLoad: null,
+      estimatedOneRepMax: null,
+    });
+    expect(addTrainingMetricsToSet({ ...baseSet, reps: null }).metrics).toEqual({
+      volumeLoad: null,
+      estimatedOneRepMax: null,
+    });
+  });
+});

--- a/shared/utils/trainingMetrics.ts
+++ b/shared/utils/trainingMetrics.ts
@@ -1,0 +1,57 @@
+import type { NormalizedWorkoutSet } from "./normalizeWorkoutSets";
+
+export type TrainingMetrics = {
+  volumeLoad: number | null;
+  estimatedOneRepMax: number | null;
+};
+
+export type NormalizedWorkoutSetWithMetrics = NormalizedWorkoutSet & {
+  metrics: TrainingMetrics;
+};
+
+const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
+
+const isPositiveNumber = (value: number | null): value is number => (
+  typeof value === "number" && value > 0
+);
+
+export const calculateVolumeLoad = (
+  weight: number | null,
+  reps: number | null
+): number | null => {
+  if (!isPositiveNumber(weight) || !isPositiveNumber(reps)) {
+    return null;
+  }
+
+  return roundToTwoDecimals(weight * reps);
+};
+
+export const calculateEstimatedOneRepMax = (
+  weight: number | null,
+  reps: number | null
+): number | null => {
+  if (!isPositiveNumber(weight) || !isPositiveNumber(reps)) {
+    return null;
+  }
+
+  if (reps > 12) {
+    return null;
+  }
+
+  if (reps === 1) {
+    return weight;
+  }
+
+  return roundToTwoDecimals(weight * (1 + reps / 30));
+};
+
+export const addTrainingMetricsToSet = (
+  set: NormalizedWorkoutSet
+): NormalizedWorkoutSetWithMetrics => ({
+  ...set,
+  tags: [...set.tags],
+  metrics: {
+    volumeLoad: calculateVolumeLoad(set.weight, set.reps),
+    estimatedOneRepMax: calculateEstimatedOneRepMax(set.weight, set.reps),
+  },
+});


### PR DESCRIPTION
## Summary
- Added pure training metrics utilities
- Added volume load calculation
- Added estimated 1RM calculation using the Epley formula
- Added helper to attach metrics to normalized workout sets
- Added unit tests for valid, decimal, null, zero, negative, high-rep, and immutability cases
- Updated verification docs

## Verification
- `npm test` passed
  - 8 test suites passed
  - 64 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Estimated 1RM returns `null` for reps greater than 12 to avoid over-relying on high-rep estimates
- Google Fonts download warning remains a known follow-up