### PR TITLE
Add weekly training volume utility

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -35,6 +35,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared utility tests under `shared/utils/__tests__` are included in `npm test` and CI.
 - Shared training normalization tests for `normalizeWorkoutSets` are included in `npm test` and CI.
 - Shared training metrics tests for volume load and estimated 1RM are included in `npm test` and CI.
+- Shared weekly training volume tests are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -46,7 +47,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics utilities for weekly volume, PR detection, and BIG3 trend analysis.
+- Add analytics utilities for PR detection and BIG3 trend analysis, then wire graph UI.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/weeklyTrainingVolume.spec.ts
+++ b/shared/utils/__tests__/weeklyTrainingVolume.spec.ts
@@ -1,0 +1,157 @@
+import {
+  aggregateWeeklyTrainingVolume,
+  getWeekStart,
+} from "../weeklyTrainingVolume";
+import type { NormalizedWorkoutSetWithMetrics } from "../trainingMetrics";
+
+const createSet = (
+  overrides: Partial<NormalizedWorkoutSetWithMetrics>
+): NormalizedWorkoutSetWithMetrics => ({
+  date: "2026-06-08",
+  userId: "user-1",
+  exerciseName: "Bench Press",
+  exerciseNote: null,
+  setIndex: 0,
+  weight: 100,
+  reps: 5,
+  restSeconds: 180,
+  rpe: null,
+  rir: null,
+  failure: null,
+  tags: [],
+  metrics: {
+    volumeLoad: 500,
+    estimatedOneRepMax: 116.67,
+  },
+  ...overrides,
+});
+
+describe("getWeekStart", () => {
+  it("returns Monday itself", () => {
+    expect(getWeekStart("2026-06-08")).toBe("2026-06-08");
+  });
+
+  it("returns the same Monday for Tuesday", () => {
+    expect(getWeekStart("2026-06-09")).toBe("2026-06-08");
+  });
+
+  it("returns the same Monday for Sunday", () => {
+    expect(getWeekStart("2026-06-14")).toBe("2026-06-08");
+  });
+
+  it("returns next Monday itself", () => {
+    expect(getWeekStart("2026-06-15")).toBe("2026-06-15");
+  });
+
+  it("returns null for invalid, null, or empty dates", () => {
+    expect(getWeekStart("not-a-date")).toBeNull();
+    expect(getWeekStart("2026-02-30")).toBeNull();
+    expect(getWeekStart(null)).toBeNull();
+    expect(getWeekStart("")).toBeNull();
+    expect(getWeekStart("   ")).toBeNull();
+  });
+});
+
+describe("aggregateWeeklyTrainingVolume", () => {
+  it("groups by weekStart and exerciseName, sums volume, and counts sets", () => {
+    expect(
+      aggregateWeeklyTrainingVolume([
+        createSet({ date: "2026-06-09", exerciseName: "Bench Press", metrics: { volumeLoad: 500, estimatedOneRepMax: 116.67 } }),
+        createSet({ date: "2026-06-10", exerciseName: "Bench Press", metrics: { volumeLoad: 450, estimatedOneRepMax: 110 } }),
+        createSet({ date: "2026-06-10", exerciseName: "Squat", metrics: { volumeLoad: 900, estimatedOneRepMax: 150 } }),
+      ])
+    ).toEqual([
+      {
+        weekStart: "2026-06-08",
+        exerciseName: "Bench Press",
+        totalSets: 2,
+        totalVolumeLoad: 950,
+        averageRpe: null,
+        averageRir: null,
+      },
+      {
+        weekStart: "2026-06-08",
+        exerciseName: "Squat",
+        totalSets: 1,
+        totalVolumeLoad: 900,
+        averageRpe: null,
+        averageRir: null,
+      },
+    ]);
+  });
+
+  it("averages rpe and rir while ignoring null values", () => {
+    expect(
+      aggregateWeeklyTrainingVolume([
+        createSet({ rpe: 8, rir: 2 }),
+        createSet({ rpe: null, rir: 1 }),
+        createSet({ rpe: 9, rir: null }),
+      ])
+    ).toEqual([
+      {
+        weekStart: "2026-06-08",
+        exerciseName: "Bench Press",
+        totalSets: 3,
+        totalVolumeLoad: 1500,
+        averageRpe: 8.5,
+        averageRir: 1.5,
+      },
+    ]);
+  });
+
+  it("returns null averages when no rpe or rir values exist", () => {
+    const rows = aggregateWeeklyTrainingVolume([
+      createSet({ rpe: null, rir: null }),
+      createSet({ rpe: null, rir: null }),
+    ]);
+
+    expect(rows[0]).toMatchObject({
+      averageRpe: null,
+      averageRir: null,
+    });
+  });
+
+  it("excludes rows with invalid dates", () => {
+    expect(
+      aggregateWeeklyTrainingVolume([
+        createSet({ date: "invalid-date" }),
+        createSet({ date: null }),
+        createSet({ date: "2026-06-08", exerciseName: "Deadlift" }),
+      ])
+    ).toEqual([
+      {
+        weekStart: "2026-06-08",
+        exerciseName: "Deadlift",
+        totalSets: 1,
+        totalVolumeLoad: 500,
+        averageRpe: null,
+        averageRir: null,
+      },
+    ]);
+  });
+
+  it("sorts by weekStart ascending and then exerciseName ascending", () => {
+    expect(
+      aggregateWeeklyTrainingVolume([
+        createSet({ date: "2026-06-15", exerciseName: "Squat" }),
+        createSet({ date: "2026-06-08", exerciseName: "Deadlift" }),
+        createSet({ date: "2026-06-08", exerciseName: "Bench Press" }),
+      ]).map(({ weekStart, exerciseName }) => ({ weekStart, exerciseName }))
+    ).toEqual([
+      { weekStart: "2026-06-08", exerciseName: "Bench Press" },
+      { weekStart: "2026-06-08", exerciseName: "Deadlift" },
+      { weekStart: "2026-06-15", exerciseName: "Squat" },
+    ]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [
+      createSet({ date: "2026-06-08", exerciseName: "Bench Press", tags: ["push"] }),
+    ];
+    const original = JSON.stringify(input);
+
+    aggregateWeeklyTrainingVolume(input);
+
+    expect(JSON.stringify(input)).toBe(original);
+  });
+});

--- a/shared/utils/weeklyTrainingVolume.ts
+++ b/shared/utils/weeklyTrainingVolume.ts
@@ -1,0 +1,125 @@
+import type { NormalizedWorkoutSetWithMetrics } from "./trainingMetrics";
+
+export type WeeklyTrainingVolumeRow = {
+  weekStart: string;
+  exerciseName: string;
+  totalSets: number;
+  totalVolumeLoad: number;
+  averageRpe: number | null;
+  averageRir: number | null;
+};
+
+type WeeklyTrainingVolumeAccumulator = {
+  weekStart: string;
+  exerciseName: string;
+  totalSets: number;
+  totalVolumeLoad: number;
+  rpeTotal: number;
+  rpeCount: number;
+  rirTotal: number;
+  rirCount: number;
+};
+
+const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
+
+const isFiniteNumber = (value: number | null): value is number => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+export const getWeekStart = (date: string | null | undefined): string | null => {
+  if (!date || date.trim() === "") {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const dayOfMonth = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, monthIndex, dayOfMonth));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== dayOfMonth
+  ) {
+    return null;
+  }
+
+  const dayOfWeek = parsed.getUTCDay();
+  const daysFromMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  parsed.setUTCDate(parsed.getUTCDate() - daysFromMonday);
+
+  return parsed.toISOString().slice(0, 10);
+};
+
+export const aggregateWeeklyTrainingVolume = (
+  sets: NormalizedWorkoutSetWithMetrics[]
+): WeeklyTrainingVolumeRow[] => {
+  if (!Array.isArray(sets) || sets.length === 0) {
+    return [];
+  }
+
+  const groups = new Map<string, WeeklyTrainingVolumeAccumulator>();
+
+  sets.forEach((set) => {
+    const weekStart = getWeekStart(set.date);
+    if (!weekStart) {
+      return;
+    }
+
+    const key = `${weekStart}\u0000${set.exerciseName}`;
+    const current = groups.get(key) ?? {
+      weekStart,
+      exerciseName: set.exerciseName,
+      totalSets: 0,
+      totalVolumeLoad: 0,
+      rpeTotal: 0,
+      rpeCount: 0,
+      rirTotal: 0,
+      rirCount: 0,
+    };
+
+    current.totalSets += 1;
+
+    if (isFiniteNumber(set.metrics.volumeLoad)) {
+      current.totalVolumeLoad += set.metrics.volumeLoad;
+    }
+
+    if (isFiniteNumber(set.rpe)) {
+      current.rpeTotal += set.rpe;
+      current.rpeCount += 1;
+    }
+
+    if (isFiniteNumber(set.rir)) {
+      current.rirTotal += set.rir;
+      current.rirCount += 1;
+    }
+
+    groups.set(key, current);
+  });
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      weekStart: group.weekStart,
+      exerciseName: group.exerciseName,
+      totalSets: group.totalSets,
+      totalVolumeLoad: roundToTwoDecimals(group.totalVolumeLoad),
+      averageRpe: group.rpeCount > 0
+        ? roundToTwoDecimals(group.rpeTotal / group.rpeCount)
+        : null,
+      averageRir: group.rirCount > 0
+        ? roundToTwoDecimals(group.rirTotal / group.rirCount)
+        : null,
+    }))
+    .sort((a, b) => {
+      const weekCompare = a.weekStart.localeCompare(b.weekStart);
+      if (weekCompare !== 0) {
+        return weekCompare;
+      }
+      return a.exerciseName.localeCompare(b.exerciseName);
+    });
+};


### PR DESCRIPTION
## Summary
- Added a pure weekly training volume utility
- Added Monday-start week calculation
- Aggregated training volume by `weekStart + exerciseName`
- Added set count, total volume load, average RPE, and average RIR
- Added tests for week start calculation, grouping, totals, averages, invalid dates, sorting, and immutability
- Updated verification docs

## Verification
- `npm test` passed
  - 9 test suites passed
  - 75 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Google Fonts download warning remains a known follow-up