### PR TITLE
Add training personal record detection

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -36,6 +36,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training normalization tests for `normalizeWorkoutSets` are included in `npm test` and CI.
 - Shared training metrics tests for volume load and estimated 1RM are included in `npm test` and CI.
 - Shared weekly training volume tests are included in `npm test` and CI.
+- Shared training personal record detection tests are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -47,7 +48,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics utilities for PR detection and BIG3 trend analysis, then wire graph UI.
+- Add analytics utilities for BIG3 trend analysis, then wire graph UI.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/trainingPersonalRecords.spec.ts
+++ b/shared/utils/__tests__/trainingPersonalRecords.spec.ts
@@ -1,0 +1,199 @@
+import { findExercisePersonalRecords } from "../trainingPersonalRecords";
+import type { NormalizedWorkoutSetWithMetrics } from "../trainingMetrics";
+
+type SetOverrides = Partial<Omit<NormalizedWorkoutSetWithMetrics, "metrics">> & {
+  metrics?: Partial<NormalizedWorkoutSetWithMetrics["metrics"]>;
+};
+
+const createSet = (overrides: SetOverrides = {}): NormalizedWorkoutSetWithMetrics => {
+  const { metrics, ...rest } = overrides;
+
+  return {
+    date: "2026-06-10",
+    userId: "user-1",
+    exerciseName: "Bench Press",
+    exerciseNote: null,
+    setIndex: 0,
+    weight: 100,
+    reps: 5,
+    restSeconds: 180,
+    rpe: null,
+    rir: null,
+    failure: null,
+    tags: [],
+    metrics: {
+      volumeLoad: 500,
+      estimatedOneRepMax: 116.67,
+      ...metrics,
+    },
+    ...rest,
+  };
+};
+
+describe("findExercisePersonalRecords", () => {
+  it("returns an empty array for empty input", () => {
+    expect(findExercisePersonalRecords([])).toEqual([]);
+  });
+
+  it("groups by exerciseName", () => {
+    expect(
+      findExercisePersonalRecords([
+        createSet({ exerciseName: "Squat", weight: 140, reps: 3, metrics: { volumeLoad: 420, estimatedOneRepMax: 154 } }),
+        createSet({ exerciseName: "Bench Press", weight: 100, reps: 5 }),
+      ]).map(({ exerciseName }) => exerciseName)
+    ).toEqual(["Bench Press", "Squat"]);
+  });
+
+  it("detects max estimated 1RM", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({ date: "2026-06-10", metrics: { estimatedOneRepMax: 116.67 } }),
+      createSet({ date: "2026-06-12", metrics: { estimatedOneRepMax: 125 } }),
+    ]);
+
+    expect(records.maxEstimatedOneRepMax).toMatchObject({
+      date: "2026-06-12",
+      estimatedOneRepMax: 125,
+    });
+  });
+
+  it("detects max weight", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({ date: "2026-06-10", weight: 100 }),
+      createSet({ date: "2026-06-12", weight: 102.5 }),
+    ]);
+
+    expect(records.maxWeight).toMatchObject({
+      date: "2026-06-12",
+      weight: 102.5,
+    });
+  });
+
+  it("detects max reps", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({ date: "2026-06-10", reps: 5 }),
+      createSet({ date: "2026-06-12", reps: 8 }),
+    ]);
+
+    expect(records.maxReps).toMatchObject({
+      date: "2026-06-12",
+      reps: 8,
+    });
+  });
+
+  it("detects max volume load", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({ date: "2026-06-10", metrics: { volumeLoad: 500 } }),
+      createSet({ date: "2026-06-12", metrics: { volumeLoad: 650 } }),
+    ]);
+
+    expect(records.maxVolumeLoad).toMatchObject({
+      date: "2026-06-12",
+      volumeLoad: 650,
+    });
+  });
+
+  it("ignores empty exerciseName", () => {
+    expect(
+      findExercisePersonalRecords([
+        createSet({ exerciseName: "" }),
+        createSet({ exerciseName: "   " }),
+      ])
+    ).toEqual([]);
+  });
+
+  it("ignores invalid, null, or empty dates", () => {
+    expect(
+      findExercisePersonalRecords([
+        createSet({ date: "not-a-date" }),
+        createSet({ date: "2026-02-30" }),
+        createSet({ date: null }),
+        createSet({ date: "" }),
+        createSet({ date: "2026-06-10", exerciseName: "Deadlift" }),
+      ])
+    ).toHaveLength(1);
+    expect(
+      findExercisePersonalRecords([
+        createSet({ date: "not-a-date" }),
+        createSet({ date: "2026-02-30" }),
+        createSet({ date: null }),
+        createSet({ date: "" }),
+        createSet({ date: "2026-06-10", exerciseName: "Deadlift" }),
+      ])[0].exerciseName
+    ).toBe("Deadlift");
+  });
+
+  it("ignores null, non-finite, zero, and negative metric values", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({
+        weight: 0,
+        reps: -1,
+        metrics: {
+          volumeLoad: Number.NaN,
+          estimatedOneRepMax: Number.POSITIVE_INFINITY,
+        },
+      }),
+      createSet({
+        date: "2026-06-12",
+        weight: 110,
+        reps: 4,
+        metrics: {
+          volumeLoad: 440,
+          estimatedOneRepMax: 124.67,
+        },
+      }),
+    ]);
+
+    expect(records).toMatchObject({
+      maxEstimatedOneRepMax: { date: "2026-06-12", estimatedOneRepMax: 124.67 },
+      maxWeight: { date: "2026-06-12", weight: 110 },
+      maxReps: { date: "2026-06-12", reps: 4 },
+      maxVolumeLoad: { date: "2026-06-12", volumeLoad: 440 },
+    });
+  });
+
+  it("tie breaks by earliest date", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({ date: "2026-06-12", weight: 100 }),
+      createSet({ date: "2026-06-10", weight: 100 }),
+    ]);
+
+    expect(records.maxWeight).toMatchObject({
+      date: "2026-06-10",
+      weight: 100,
+    });
+  });
+
+  it("tie breaks by smaller setIndex when date is the same", () => {
+    const [records] = findExercisePersonalRecords([
+      createSet({ date: "2026-06-10", setIndex: 2, reps: 8 }),
+      createSet({ date: "2026-06-10", setIndex: 1, reps: 8 }),
+    ]);
+
+    expect(records.maxReps).toMatchObject({
+      date: "2026-06-10",
+      setIndex: 1,
+      reps: 8,
+    });
+  });
+
+  it("sorts output by exerciseName ascending", () => {
+    expect(
+      findExercisePersonalRecords([
+        createSet({ exerciseName: "Squat" }),
+        createSet({ exerciseName: "Deadlift" }),
+        createSet({ exerciseName: "Bench Press" }),
+      ]).map(({ exerciseName }) => exerciseName)
+    ).toEqual(["Bench Press", "Deadlift", "Squat"]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [
+      createSet({ exerciseName: "Bench Press", tags: ["push"] }),
+    ];
+    const original = JSON.stringify(input);
+
+    findExercisePersonalRecords(input);
+
+    expect(JSON.stringify(input)).toBe(original);
+  });
+});

--- a/shared/utils/trainingPersonalRecords.ts
+++ b/shared/utils/trainingPersonalRecords.ts
@@ -1,0 +1,173 @@
+import type { NormalizedWorkoutSetWithMetrics } from "./trainingMetrics";
+
+export type PersonalRecordSet = {
+  date: string;
+  exerciseName: string;
+  setIndex: number;
+  weight: number | null;
+  reps: number | null;
+  volumeLoad: number | null;
+  estimatedOneRepMax: number | null;
+};
+
+export type ExercisePersonalRecords = {
+  exerciseName: string;
+  maxEstimatedOneRepMax: PersonalRecordSet | null;
+  maxWeight: PersonalRecordSet | null;
+  maxReps: PersonalRecordSet | null;
+  maxVolumeLoad: PersonalRecordSet | null;
+};
+
+const isPositiveFiniteNumber = (value: number | null | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value > 0
+);
+
+const getValidDate = (date: string | null | undefined): string | null => {
+  if (!date || date.trim() === "") {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const dayOfMonth = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, monthIndex, dayOfMonth));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== dayOfMonth
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+const toPositiveNumberOrNull = (value: number | null): number | null => (
+  isPositiveFiniteNumber(value) ? value : null
+);
+
+const toPersonalRecordSet = (
+  set: NormalizedWorkoutSetWithMetrics,
+  date: string
+): PersonalRecordSet => ({
+  date,
+  exerciseName: set.exerciseName,
+  setIndex: set.setIndex,
+  weight: toPositiveNumberOrNull(set.weight),
+  reps: toPositiveNumberOrNull(set.reps),
+  volumeLoad: toPositiveNumberOrNull(set.metrics.volumeLoad),
+  estimatedOneRepMax: toPositiveNumberOrNull(set.metrics.estimatedOneRepMax),
+});
+
+const pickBetterRecord = (
+  current: PersonalRecordSet | null,
+  candidate: PersonalRecordSet,
+  candidateValue: number,
+  getCurrentValue: (record: PersonalRecordSet) => number | null
+): PersonalRecordSet => {
+  if (!current) {
+    return candidate;
+  }
+
+  const currentValue = getCurrentValue(current);
+  if (!isPositiveFiniteNumber(currentValue)) {
+    return candidate;
+  }
+
+  if (candidateValue > currentValue) {
+    return candidate;
+  }
+
+  if (candidateValue < currentValue) {
+    return current;
+  }
+
+  const dateCompare = candidate.date.localeCompare(current.date);
+  if (dateCompare < 0) {
+    return candidate;
+  }
+
+  if (dateCompare > 0) {
+    return current;
+  }
+
+  return candidate.setIndex < current.setIndex ? candidate : current;
+};
+
+export const findExercisePersonalRecords = (
+  sets: NormalizedWorkoutSetWithMetrics[]
+): ExercisePersonalRecords[] => {
+  if (!Array.isArray(sets) || sets.length === 0) {
+    return [];
+  }
+
+  const groups = new Map<string, ExercisePersonalRecords>();
+
+  sets.forEach((set) => {
+    if (set.exerciseName.trim() === "") {
+      return;
+    }
+
+    const date = getValidDate(set.date);
+    if (!date) {
+      return;
+    }
+
+    const record = toPersonalRecordSet(set, date);
+    const group = groups.get(set.exerciseName) ?? {
+      exerciseName: set.exerciseName,
+      maxEstimatedOneRepMax: null,
+      maxWeight: null,
+      maxReps: null,
+      maxVolumeLoad: null,
+    };
+
+    if (isPositiveFiniteNumber(record.estimatedOneRepMax)) {
+      group.maxEstimatedOneRepMax = pickBetterRecord(
+        group.maxEstimatedOneRepMax,
+        record,
+        record.estimatedOneRepMax,
+        (current) => current.estimatedOneRepMax
+      );
+    }
+
+    if (isPositiveFiniteNumber(record.weight)) {
+      group.maxWeight = pickBetterRecord(
+        group.maxWeight,
+        record,
+        record.weight,
+        (current) => current.weight
+      );
+    }
+
+    if (isPositiveFiniteNumber(record.reps)) {
+      group.maxReps = pickBetterRecord(
+        group.maxReps,
+        record,
+        record.reps,
+        (current) => current.reps
+      );
+    }
+
+    if (isPositiveFiniteNumber(record.volumeLoad)) {
+      group.maxVolumeLoad = pickBetterRecord(
+        group.maxVolumeLoad,
+        record,
+        record.volumeLoad,
+        (current) => current.volumeLoad
+      );
+    }
+
+    groups.set(set.exerciseName, group);
+  });
+
+  return Array.from(groups.values()).sort((a, b) => (
+    a.exerciseName.localeCompare(b.exerciseName)
+  ));
+};


### PR DESCRIPTION
## Summary
- Added a pure personal record detection utility
- Detects exercise-level PRs for estimated 1RM, max weight, max reps, and max volume load
- Excludes invalid dates, empty exercise names, and invalid metric values
- Added deterministic tie-break behavior by earliest date and smaller set index
- Added unit tests for grouping, PR detection, filtering, sorting, tie-breaks, and immutability
- Updated verification docs

## Verification
- `npm test` passed
  - 10 test suites passed
  - 88 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Google Fonts download warning remains a known follow-up