### PR TITLE
Add exercise metadata canonicalization

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -37,6 +37,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training metrics tests for volume load and estimated 1RM are included in `npm test` and CI.
 - Shared weekly training volume tests are included in `npm test` and CI.
 - Shared training personal record detection tests are included in `npm test` and CI.
+- Shared exercise metadata canonicalization tests are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -48,7 +49,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics utilities for BIG3 trend analysis, then wire graph UI.
+- Add analytics utilities for BIG3 trend and muscle group volume analysis, then wire graph UI.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/constants/exerciseMetadata.ts
+++ b/shared/constants/exerciseMetadata.ts
@@ -1,0 +1,159 @@
+export type LiftType = "squat" | "bench" | "deadlift" | null;
+
+export type ExerciseMetadata = {
+  id: string;
+  canonicalName: string;
+  aliases: string[];
+  primaryMuscles: string[];
+  secondaryMuscles?: string[];
+  movementPattern?: string;
+  exerciseCategory?: string;
+  liftType?: LiftType;
+};
+
+export const EXERCISE_METADATA: ExerciseMetadata[] = [
+  {
+    id: "bench_press",
+    canonicalName: "Bench Press",
+    aliases: [
+      "bench press",
+      "Bench",
+      "Competition Bench",
+      "Paused Bench Press",
+      "ベンチプレス",
+    ],
+    primaryMuscles: ["chest", "triceps", "front_delts"],
+    secondaryMuscles: ["shoulders"],
+    movementPattern: "horizontal_push",
+    exerciseCategory: "barbell",
+    liftType: "bench",
+  },
+  {
+    id: "squat",
+    canonicalName: "Squat",
+    aliases: [
+      "squat",
+      "Back Squat",
+      "Barbell Squat",
+      "スクワット",
+    ],
+    primaryMuscles: ["quads", "glutes"],
+    secondaryMuscles: ["hamstrings", "core"],
+    movementPattern: "squat",
+    exerciseCategory: "barbell",
+    liftType: "squat",
+  },
+  {
+    id: "deadlift",
+    canonicalName: "Deadlift",
+    aliases: [
+      "deadlift",
+      "Conventional Deadlift",
+      "デッドリフト",
+    ],
+    primaryMuscles: ["hamstrings", "glutes", "back"],
+    secondaryMuscles: ["forearms", "core"],
+    movementPattern: "hinge",
+    exerciseCategory: "barbell",
+    liftType: "deadlift",
+  },
+  {
+    id: "overhead_press",
+    canonicalName: "Overhead Press",
+    aliases: [
+      "overhead press",
+      "OHP",
+      "Military Press",
+      "ショルダープレス",
+    ],
+    primaryMuscles: ["shoulders", "triceps"],
+    secondaryMuscles: ["upper_chest", "core"],
+    movementPattern: "vertical_push",
+    exerciseCategory: "barbell",
+    liftType: null,
+  },
+  {
+    id: "barbell_row",
+    canonicalName: "Barbell Row",
+    aliases: [
+      "barbell row",
+      "Bent Over Row",
+      "ベントオーバーロウ",
+    ],
+    primaryMuscles: ["back", "lats"],
+    secondaryMuscles: ["biceps", "rear_delts"],
+    movementPattern: "horizontal_pull",
+    exerciseCategory: "barbell",
+    liftType: null,
+  },
+  {
+    id: "pull_up",
+    canonicalName: "Pull Up",
+    aliases: [
+      "pull up",
+      "Pullup",
+      "Chin Up",
+      "懸垂",
+    ],
+    primaryMuscles: ["lats", "back"],
+    secondaryMuscles: ["biceps", "forearms"],
+    movementPattern: "vertical_pull",
+    exerciseCategory: "bodyweight",
+    liftType: null,
+  },
+  {
+    id: "lat_pulldown",
+    canonicalName: "Lat Pulldown",
+    aliases: [
+      "lat pulldown",
+      "Lat Pull Down",
+      "ラットプルダウン",
+    ],
+    primaryMuscles: ["lats", "back"],
+    secondaryMuscles: ["biceps"],
+    movementPattern: "vertical_pull",
+    exerciseCategory: "machine",
+    liftType: null,
+  },
+  {
+    id: "leg_press",
+    canonicalName: "Leg Press",
+    aliases: [
+      "leg press",
+      "レッグプレス",
+    ],
+    primaryMuscles: ["quads", "glutes"],
+    secondaryMuscles: ["hamstrings"],
+    movementPattern: "squat",
+    exerciseCategory: "machine",
+    liftType: null,
+  },
+  {
+    id: "romanian_deadlift",
+    canonicalName: "Romanian Deadlift",
+    aliases: [
+      "romanian deadlift",
+      "RDL",
+      "ルーマニアンデッドリフト",
+    ],
+    primaryMuscles: ["hamstrings", "glutes"],
+    secondaryMuscles: ["back"],
+    movementPattern: "hinge",
+    exerciseCategory: "barbell",
+    liftType: null,
+  },
+  {
+    id: "dumbbell_press",
+    canonicalName: "Dumbbell Press",
+    aliases: [
+      "dumbbell press",
+      "DB Press",
+      "ダンベルプレス",
+    ],
+    primaryMuscles: ["chest", "triceps"],
+    secondaryMuscles: ["front_delts"],
+    movementPattern: "horizontal_push",
+    exerciseCategory: "dumbbell",
+    liftType: null,
+  },
+];

--- a/shared/utils/__tests__/exerciseCanonicalization.spec.ts
+++ b/shared/utils/__tests__/exerciseCanonicalization.spec.ts
@@ -1,0 +1,93 @@
+import { EXERCISE_METADATA } from "../../constants/exerciseMetadata";
+import {
+  findExerciseMetadataByName,
+  getCanonicalExerciseName,
+  getExerciseLiftType,
+} from "../exerciseCanonicalization";
+
+describe("exercise canonicalization", () => {
+  it("matches canonicalName exactly", () => {
+    expect(findExerciseMetadataByName("Bench Press")?.canonicalName).toBe("Bench Press");
+    expect(getCanonicalExerciseName("Bench Press")).toBe("Bench Press");
+  });
+
+  it("matches canonicalName case-insensitively", () => {
+    expect(findExerciseMetadataByName("bench press")?.canonicalName).toBe("Bench Press");
+    expect(getCanonicalExerciseName("bench press")).toBe("Bench Press");
+  });
+
+  it("matches aliases exactly", () => {
+    expect(findExerciseMetadataByName("Competition Bench")?.canonicalName).toBe("Bench Press");
+    expect(getCanonicalExerciseName("Competition Bench")).toBe("Bench Press");
+  });
+
+  it("matches aliases case-insensitively", () => {
+    expect(findExerciseMetadataByName("competition bench")?.canonicalName).toBe("Bench Press");
+    expect(getCanonicalExerciseName("competition bench")).toBe("Bench Press");
+  });
+
+  it("matches Japanese aliases", () => {
+    expect(getCanonicalExerciseName("ベンチプレス")).toBe("Bench Press");
+    expect(getCanonicalExerciseName("懸垂")).toBe("Pull Up");
+  });
+
+  it("trims input before matching", () => {
+    expect(getCanonicalExerciseName("  Squat  ")).toBe("Squat");
+    expect(getExerciseLiftType("  Squat  ")).toBe("squat");
+  });
+
+  it("returns the original trimmed name for unmatched input", () => {
+    expect(findExerciseMetadataByName("Cable Fly")).toBeNull();
+    expect(getCanonicalExerciseName("  Cable Fly  ")).toBe("Cable Fly");
+    expect(getExerciseLiftType("Cable Fly")).toBeNull();
+  });
+
+  it("handles null, undefined, and empty input", () => {
+    expect(findExerciseMetadataByName(null)).toBeNull();
+    expect(findExerciseMetadataByName(undefined)).toBeNull();
+    expect(findExerciseMetadataByName("")).toBeNull();
+    expect(getCanonicalExerciseName(null)).toBe("");
+    expect(getCanonicalExerciseName(undefined)).toBe("");
+    expect(getCanonicalExerciseName("   ")).toBe("");
+    expect(getExerciseLiftType(null)).toBeNull();
+    expect(getExerciseLiftType(undefined)).toBeNull();
+    expect(getExerciseLiftType("")).toBeNull();
+  });
+
+  it("returns bench, squat, and deadlift lift types", () => {
+    expect(getExerciseLiftType("Bench Press")).toBe("bench");
+    expect(getExerciseLiftType("スクワット")).toBe("squat");
+    expect(getExerciseLiftType("デッドリフト")).toBe("deadlift");
+  });
+
+  it("returns null liftType for non-BIG3 exercises", () => {
+    expect(getExerciseLiftType("Overhead Press")).toBeNull();
+    expect(getExerciseLiftType("Lat Pulldown")).toBeNull();
+  });
+
+  it("includes the initial 10 metadata entries", () => {
+    const canonicalNames = EXERCISE_METADATA.map((metadata) => metadata.canonicalName);
+
+    expect(canonicalNames).toEqual([
+      "Bench Press",
+      "Squat",
+      "Deadlift",
+      "Overhead Press",
+      "Barbell Row",
+      "Pull Up",
+      "Lat Pulldown",
+      "Leg Press",
+      "Romanian Deadlift",
+      "Dumbbell Press",
+    ]);
+  });
+
+  it("does not mutate input", () => {
+    const input = "  bench press  ";
+
+    getCanonicalExerciseName(input);
+    getExerciseLiftType(input);
+
+    expect(input).toBe("  bench press  ");
+  });
+});

--- a/shared/utils/exerciseCanonicalization.ts
+++ b/shared/utils/exerciseCanonicalization.ts
@@ -1,0 +1,57 @@
+import {
+  EXERCISE_METADATA,
+  ExerciseMetadata,
+  LiftType,
+} from "../constants/exerciseMetadata";
+
+const normalizeForMatch = (value: string): string => value.trim().toLowerCase();
+
+export const findExerciseMetadataByName = (
+  rawExerciseName: string | null | undefined
+): ExerciseMetadata | null => {
+  const trimmed = rawExerciseName?.trim() ?? "";
+  if (trimmed === "") {
+    return null;
+  }
+
+  const canonicalExact = EXERCISE_METADATA.find(
+    (metadata) => metadata.canonicalName === trimmed
+  );
+  if (canonicalExact) {
+    return canonicalExact;
+  }
+
+  const normalized = normalizeForMatch(trimmed);
+  const canonicalCaseInsensitive = EXERCISE_METADATA.find(
+    (metadata) => normalizeForMatch(metadata.canonicalName) === normalized
+  );
+  if (canonicalCaseInsensitive) {
+    return canonicalCaseInsensitive;
+  }
+
+  const aliasExact = EXERCISE_METADATA.find((metadata) => (
+    metadata.aliases.some((alias) => alias === trimmed)
+  ));
+  if (aliasExact) {
+    return aliasExact;
+  }
+
+  return EXERCISE_METADATA.find((metadata) => (
+    metadata.aliases.some((alias) => normalizeForMatch(alias) === normalized)
+  )) ?? null;
+};
+
+export const getCanonicalExerciseName = (
+  rawExerciseName: string | null | undefined
+): string => {
+  const trimmed = rawExerciseName?.trim() ?? "";
+  if (trimmed === "") {
+    return "";
+  }
+
+  return findExerciseMetadataByName(trimmed)?.canonicalName ?? trimmed;
+};
+
+export const getExerciseLiftType = (
+  rawExerciseName: string | null | undefined
+): LiftType => findExerciseMetadataByName(rawExerciseName)?.liftType ?? null;


### PR DESCRIPTION
## Summary
- Added initial shared exercise metadata
- Added canonicalization utilities for raw exercise names
- Added support for canonical name, aliases, Japanese aliases, and BIG3 lift type lookup
- Added unit tests for exact match, case-insensitive match, alias match, Japanese alias match, unmatched fallback, lift types, and immutability
- Updated verification docs

## Verification
- `npm test` passed
  - 11 test suites passed
  - 100 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Google Fonts download warning remains a known follow-up