### PR TITLE
Add BIG3 trend utility

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -38,6 +38,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared weekly training volume tests are included in `npm test` and CI.
 - Shared training personal record detection tests are included in `npm test` and CI.
 - Shared exercise metadata canonicalization tests are included in `npm test` and CI.
+- Shared BIG3 trend aggregation tests are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -49,7 +50,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics utilities for BIG3 trend and muscle group volume analysis, then wire graph UI.
+- Add analytics utilities for muscle group volume analysis, then wire graph UI.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/big3Trend.spec.ts
+++ b/shared/utils/__tests__/big3Trend.spec.ts
@@ -1,0 +1,232 @@
+import { aggregateBig3Trend } from "../big3Trend";
+import type { NormalizedWorkoutSetWithMetrics } from "../trainingMetrics";
+
+type SetOverrides = Partial<Omit<NormalizedWorkoutSetWithMetrics, "metrics">> & {
+  metrics?: Partial<NormalizedWorkoutSetWithMetrics["metrics"]>;
+};
+
+const createSet = (overrides: SetOverrides = {}): NormalizedWorkoutSetWithMetrics => {
+  const { metrics, ...rest } = overrides;
+
+  return {
+    date: "2026-06-10",
+    userId: "user-1",
+    exerciseName: "Bench Press",
+    exerciseNote: null,
+    setIndex: 0,
+    weight: 100,
+    reps: 5,
+    restSeconds: 180,
+    rpe: null,
+    rir: null,
+    failure: null,
+    tags: [],
+    metrics: {
+      volumeLoad: 500,
+      estimatedOneRepMax: 116.67,
+      ...metrics,
+    },
+    ...rest,
+  };
+};
+
+describe("aggregateBig3Trend", () => {
+  it("returns summaries for squat, bench, and deadlift", () => {
+    expect(aggregateBig3Trend([]).map(({ liftType }) => liftType)).toEqual([
+      "squat",
+      "bench",
+      "deadlift",
+    ]);
+  });
+
+  it("maps Bench Press, Japanese, and Competition Bench names to bench", () => {
+    const summaries = aggregateBig3Trend([
+      createSet({ exerciseName: "Bench Press", date: "2026-06-10" }),
+      createSet({ exerciseName: "ベンチプレス", date: "2026-06-11" }),
+      createSet({ exerciseName: "Competition Bench", date: "2026-06-12" }),
+    ]);
+    const bench = summaries.find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.points.map(({ exerciseName }) => exerciseName)).toEqual([
+      "Bench Press",
+      "ベンチプレス",
+      "Competition Bench",
+    ]);
+  });
+
+  it("maps Squat and Japanese names to squat", () => {
+    const squat = aggregateBig3Trend([
+      createSet({ exerciseName: "Squat", date: "2026-06-10" }),
+      createSet({ exerciseName: "スクワット", date: "2026-06-11" }),
+    ]).find(({ liftType }) => liftType === "squat");
+
+    expect(squat?.points).toHaveLength(2);
+  });
+
+  it("maps Deadlift and Japanese names to deadlift", () => {
+    const deadlift = aggregateBig3Trend([
+      createSet({ exerciseName: "Deadlift", date: "2026-06-10" }),
+      createSet({ exerciseName: "デッドリフト", date: "2026-06-11" }),
+    ]).find(({ liftType }) => liftType === "deadlift");
+
+    expect(deadlift?.points).toHaveLength(2);
+  });
+
+  it("excludes non-BIG3 exercises", () => {
+    const summaries = aggregateBig3Trend([
+      createSet({ exerciseName: "Overhead Press" }),
+      createSet({ exerciseName: "Romanian Deadlift" }),
+    ]);
+
+    expect(summaries.every(({ points }) => points.length === 0)).toBe(true);
+  });
+
+  it("excludes invalid, null, and empty date rows", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ date: "not-a-date" }),
+      createSet({ date: "2026-02-30" }),
+      createSet({ date: null }),
+      createSet({ date: "" }),
+      createSet({ date: "2026-06-10" }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.points).toHaveLength(1);
+  });
+
+  it("excludes rows without positive finite estimated 1RM", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ metrics: { estimatedOneRepMax: null } }),
+      createSet({ metrics: { estimatedOneRepMax: 0 } }),
+      createSet({ metrics: { estimatedOneRepMax: -1 } }),
+      createSet({ metrics: { estimatedOneRepMax: Number.NaN } }),
+      createSet({ metrics: { estimatedOneRepMax: Number.POSITIVE_INFINITY } }),
+      createSet({ metrics: { estimatedOneRepMax: 120 } }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.points).toHaveLength(1);
+    expect(bench?.points[0].estimatedOneRepMax).toBe(120);
+  });
+
+  it("keeps positive values and nulls invalid weight, reps, and volume", () => {
+    const bench = aggregateBig3Trend([
+      createSet({
+        date: "2026-06-10",
+        weight: 100,
+        reps: 5,
+        metrics: { estimatedOneRepMax: 116.67, volumeLoad: 500 },
+      }),
+      createSet({
+        date: "2026-06-11",
+        weight: -1,
+        reps: Number.POSITIVE_INFINITY,
+        metrics: { estimatedOneRepMax: 120, volumeLoad: 0 },
+      }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.points[0]).toMatchObject({
+      weight: 100,
+      reps: 5,
+      volumeLoad: 500,
+    });
+    expect(bench?.points[1]).toMatchObject({
+      weight: null,
+      reps: null,
+      volumeLoad: null,
+    });
+  });
+
+  it("sorts points by date ascending and then setIndex ascending", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ date: "2026-06-12", setIndex: 2 }),
+      createSet({ date: "2026-06-10", setIndex: 3 }),
+      createSet({ date: "2026-06-10", setIndex: 1 }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.points.map(({ date, setIndex }) => ({ date, setIndex }))).toEqual([
+      { date: "2026-06-10", setIndex: 1 },
+      { date: "2026-06-10", setIndex: 3 },
+      { date: "2026-06-12", setIndex: 2 },
+    ]);
+  });
+
+  it("detects max estimated 1RM", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ date: "2026-06-10", metrics: { estimatedOneRepMax: 120 } }),
+      createSet({ date: "2026-06-12", metrics: { estimatedOneRepMax: 130 } }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.maxEstimatedOneRepMax).toMatchObject({
+      date: "2026-06-12",
+      estimatedOneRepMax: 130,
+    });
+  });
+
+  it("tie breaks max estimated 1RM by earliest date then smaller setIndex", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ date: "2026-06-12", setIndex: 0, metrics: { estimatedOneRepMax: 130 } }),
+      createSet({ date: "2026-06-10", setIndex: 2, metrics: { estimatedOneRepMax: 130 } }),
+      createSet({ date: "2026-06-10", setIndex: 1, metrics: { estimatedOneRepMax: 130 } }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.maxEstimatedOneRepMax).toMatchObject({
+      date: "2026-06-10",
+      setIndex: 1,
+      estimatedOneRepMax: 130,
+    });
+  });
+
+  it("detects latest top set from the most recent date", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ date: "2026-06-10", metrics: { estimatedOneRepMax: 140 } }),
+      createSet({ date: "2026-06-12", setIndex: 0, metrics: { estimatedOneRepMax: 120 } }),
+      createSet({ date: "2026-06-12", setIndex: 1, metrics: { estimatedOneRepMax: 130 } }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.latestTopSet).toMatchObject({
+      date: "2026-06-12",
+      setIndex: 1,
+      estimatedOneRepMax: 130,
+    });
+  });
+
+  it("tie breaks latest top set by smaller setIndex", () => {
+    const bench = aggregateBig3Trend([
+      createSet({ date: "2026-06-12", setIndex: 2, metrics: { estimatedOneRepMax: 130 } }),
+      createSet({ date: "2026-06-12", setIndex: 1, metrics: { estimatedOneRepMax: 130 } }),
+    ]).find(({ liftType }) => liftType === "bench");
+
+    expect(bench?.latestTopSet?.setIndex).toBe(1);
+  });
+
+  it("returns empty summaries for lifts with no data", () => {
+    const summaries = aggregateBig3Trend([
+      createSet({ exerciseName: "Bench Press" }),
+    ]);
+    const squat = summaries.find(({ liftType }) => liftType === "squat");
+    const deadlift = summaries.find(({ liftType }) => liftType === "deadlift");
+
+    expect(squat).toEqual({
+      liftType: "squat",
+      points: [],
+      maxEstimatedOneRepMax: null,
+      latestTopSet: null,
+    });
+    expect(deadlift).toEqual({
+      liftType: "deadlift",
+      points: [],
+      maxEstimatedOneRepMax: null,
+      latestTopSet: null,
+    });
+  });
+
+  it("does not mutate input", () => {
+    const input = [
+      createSet({ exerciseName: "ベンチプレス", tags: ["push"] }),
+    ];
+    const original = JSON.stringify(input);
+
+    aggregateBig3Trend(input);
+
+    expect(JSON.stringify(input)).toBe(original);
+  });
+});

--- a/shared/utils/big3Trend.ts
+++ b/shared/utils/big3Trend.ts
@@ -1,0 +1,164 @@
+import type { LiftType } from "../constants/exerciseMetadata";
+import { getExerciseLiftType } from "./exerciseCanonicalization";
+import type { NormalizedWorkoutSetWithMetrics } from "./trainingMetrics";
+
+export type Big3LiftType = Exclude<LiftType, null>;
+
+export type Big3TrendPoint = {
+  date: string;
+  liftType: Big3LiftType;
+  exerciseName: string;
+  setIndex: number;
+  weight: number | null;
+  reps: number | null;
+  estimatedOneRepMax: number | null;
+  volumeLoad: number | null;
+};
+
+export type Big3TrendSummary = {
+  liftType: Big3LiftType;
+  points: Big3TrendPoint[];
+  maxEstimatedOneRepMax: Big3TrendPoint | null;
+  latestTopSet: Big3TrendPoint | null;
+};
+
+const BIG3_LIFT_TYPES: Big3LiftType[] = ["squat", "bench", "deadlift"];
+
+const isPositiveFiniteNumber = (
+  value: number | null | undefined
+): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value > 0
+);
+
+const getValidDate = (date: string | null | undefined): string | null => {
+  if (!date || date.trim() === "") {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const dayOfMonth = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, monthIndex, dayOfMonth));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== dayOfMonth
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+const toPositiveNumberOrNull = (value: number | null): number | null => (
+  isPositiveFiniteNumber(value) ? value : null
+);
+
+const compareTrendPoints = (a: Big3TrendPoint, b: Big3TrendPoint): number => {
+  const dateCompare = a.date.localeCompare(b.date);
+  return dateCompare !== 0 ? dateCompare : a.setIndex - b.setIndex;
+};
+
+const findMaxEstimatedOneRepMax = (
+  points: Big3TrendPoint[]
+): Big3TrendPoint | null => points.reduce<Big3TrendPoint | null>((best, point) => {
+  if (!best) {
+    return point;
+  }
+
+  const pointValue = point.estimatedOneRepMax as number;
+  const bestValue = best.estimatedOneRepMax as number;
+
+  if (pointValue > bestValue) {
+    return point;
+  }
+
+  if (pointValue < bestValue) {
+    return best;
+  }
+
+  return compareTrendPoints(point, best) < 0 ? point : best;
+}, null);
+
+const findLatestTopSet = (
+  points: Big3TrendPoint[]
+): Big3TrendPoint | null => {
+  if (points.length === 0) {
+    return null;
+  }
+
+  const latestDate = points[points.length - 1].date;
+  return points
+    .filter((point) => point.date === latestDate)
+    .reduce<Big3TrendPoint | null>((best, point) => {
+      if (!best) {
+        return point;
+      }
+
+      const pointValue = point.estimatedOneRepMax as number;
+      const bestValue = best.estimatedOneRepMax as number;
+
+      if (pointValue > bestValue) {
+        return point;
+      }
+
+      if (pointValue < bestValue) {
+        return best;
+      }
+
+      return point.setIndex < best.setIndex ? point : best;
+    }, null);
+};
+
+export const aggregateBig3Trend = (
+  sets: NormalizedWorkoutSetWithMetrics[]
+): Big3TrendSummary[] => {
+  const pointsByLift: Record<Big3LiftType, Big3TrendPoint[]> = {
+    squat: [],
+    bench: [],
+    deadlift: [],
+  };
+
+  if (Array.isArray(sets)) {
+    sets.forEach((set) => {
+      const liftType = getExerciseLiftType(set.exerciseName);
+      if (!liftType) {
+        return;
+      }
+
+      const date = getValidDate(set.date);
+      const estimatedOneRepMax = set.metrics.estimatedOneRepMax;
+      if (!date || !isPositiveFiniteNumber(estimatedOneRepMax)) {
+        return;
+      }
+
+      pointsByLift[liftType].push({
+        date,
+        liftType,
+        exerciseName: set.exerciseName,
+        setIndex: set.setIndex,
+        weight: toPositiveNumberOrNull(set.weight),
+        reps: toPositiveNumberOrNull(set.reps),
+        estimatedOneRepMax,
+        volumeLoad: toPositiveNumberOrNull(set.metrics.volumeLoad),
+      });
+    });
+  }
+
+  return BIG3_LIFT_TYPES.map((liftType) => {
+    const points = [...pointsByLift[liftType]].sort(compareTrendPoints);
+
+    return {
+      liftType,
+      points,
+      maxEstimatedOneRepMax: findMaxEstimatedOneRepMax(points),
+      latestTopSet: findLatestTopSet(points),
+    };
+  });
+};


### PR DESCRIPTION
## Summary
- Added a pure BIG3 trend aggregation utility
- Uses exercise metadata `liftType` to classify squat, bench, and deadlift sets
- Aggregates trend points, max estimated 1RM, and latest top set for each BIG3 lift
- Handles English names, Japanese aliases, and aliases such as Competition Bench
- Added tests for classification, filtering, sorting, PR selection, latest top set, empty summaries, and immutability
- Updated verification docs

## Verification
- `npm test` passed
  - 12 test suites passed
  - 115 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Google Fonts download warning remains a known follow-up