### PR TITLE
Add muscle group volume utility

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -39,6 +39,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training personal record detection tests are included in `npm test` and CI.
 - Shared exercise metadata canonicalization tests are included in `npm test` and CI.
 - Shared BIG3 trend aggregation tests are included in `npm test` and CI.
+- Shared weekly muscle group volume aggregation tests are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -50,7 +51,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics utilities for muscle group volume analysis, then wire graph UI.
+- Add graph data/UI integration, RPE/RIR input, and AI weekly summaries.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/muscleGroupVolume.spec.ts
+++ b/shared/utils/__tests__/muscleGroupVolume.spec.ts
@@ -1,0 +1,186 @@
+import { aggregateWeeklyMuscleGroupVolume } from "../muscleGroupVolume";
+import type { NormalizedWorkoutSetWithMetrics } from "../trainingMetrics";
+
+type SetOverrides = Partial<Omit<NormalizedWorkoutSetWithMetrics, "metrics">> & {
+  metrics?: Partial<NormalizedWorkoutSetWithMetrics["metrics"]>;
+};
+
+const createSet = (overrides: SetOverrides = {}): NormalizedWorkoutSetWithMetrics => {
+  const { metrics, ...rest } = overrides;
+
+  return {
+    date: "2026-06-23",
+    userId: "user-1",
+    exerciseName: "Bench Press",
+    exerciseNote: null,
+    setIndex: 0,
+    weight: 100,
+    reps: 5,
+    restSeconds: 180,
+    rpe: null,
+    rir: null,
+    failure: null,
+    tags: [],
+    metrics: {
+      volumeLoad: 500,
+      estimatedOneRepMax: 116.67,
+      ...metrics,
+    },
+    ...rest,
+  };
+};
+
+describe("aggregateWeeklyMuscleGroupVolume", () => {
+  it("returns an empty array for empty input", () => {
+    expect(aggregateWeeklyMuscleGroupVolume([])).toEqual([]);
+  });
+
+  it("groups by weekStart and muscle", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ date: "2026-06-23" }),
+      createSet({ date: "2026-06-30" }),
+    ]);
+
+    expect(rows.filter(({ muscle }) => muscle === "chest")).toEqual([
+      {
+        weekStart: "2026-06-22",
+        muscle: "chest",
+        totalSets: 1,
+        totalVolumeLoad: 500,
+        exercises: ["Bench Press"],
+      },
+      {
+        weekStart: "2026-06-29",
+        muscle: "chest",
+        totalSets: 1,
+        totalVolumeLoad: 500,
+        exercises: ["Bench Press"],
+      },
+    ]);
+  });
+
+  it("counts one set for each primary muscle", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([createSet()]);
+
+    expect(rows.map(({ muscle, totalSets }) => ({ muscle, totalSets }))).toEqual([
+      { muscle: "chest", totalSets: 1 },
+      { muscle: "front_delts", totalSets: 1 },
+      { muscle: "triceps", totalSets: 1 },
+    ]);
+  });
+
+  it("sums positive volume load", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ metrics: { volumeLoad: 500 } }),
+      createSet({ setIndex: 1, metrics: { volumeLoad: 612.5 } }),
+    ]);
+    const chest = rows.find(({ muscle }) => muscle === "chest");
+
+    expect(chest).toMatchObject({
+      totalSets: 2,
+      totalVolumeLoad: 1112.5,
+    });
+  });
+
+  it("ignores invalid volume values but still counts their sets", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ metrics: { volumeLoad: null } }),
+      createSet({ setIndex: 1, metrics: { volumeLoad: Number.NaN } }),
+      createSet({ setIndex: 2, metrics: { volumeLoad: Number.POSITIVE_INFINITY } }),
+      createSet({ setIndex: 3, metrics: { volumeLoad: 0 } }),
+      createSet({ setIndex: 4, metrics: { volumeLoad: -100 } }),
+    ]);
+    const chest = rows.find(({ muscle }) => muscle === "chest");
+
+    expect(chest).toMatchObject({
+      totalSets: 5,
+      totalVolumeLoad: 0,
+    });
+  });
+
+  it("excludes unmatched exercise names", () => {
+    expect(
+      aggregateWeeklyMuscleGroupVolume([
+        createSet({ exerciseName: "Cable Fly" }),
+      ])
+    ).toEqual([]);
+  });
+
+  it("excludes invalid, null, and empty date rows", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ date: "not-a-date" }),
+      createSet({ date: "2026-02-30" }),
+      createSet({ date: null }),
+      createSet({ date: "" }),
+      createSet({ date: "2026-06-23" }),
+    ]);
+
+    expect(rows.every(({ totalSets }) => totalSets === 1)).toBe(true);
+  });
+
+  it("keeps unique sorted canonical exercise names", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ exerciseName: "Bench Press" }),
+      createSet({ exerciseName: "ベンチプレス", setIndex: 1 }),
+      createSet({ exerciseName: "Dumbbell Press", setIndex: 2 }),
+    ]);
+    const chest = rows.find(({ muscle }) => muscle === "chest");
+
+    expect(chest?.exercises).toEqual(["Bench Press", "Dumbbell Press"]);
+  });
+
+  it("sorts output by weekStart ascending and then muscle ascending", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ date: "2026-06-30", exerciseName: "Squat" }),
+      createSet({ date: "2026-06-23", exerciseName: "Bench Press" }),
+    ]);
+
+    expect(rows.map(({ weekStart, muscle }) => ({ weekStart, muscle }))).toEqual([
+      { weekStart: "2026-06-22", muscle: "chest" },
+      { weekStart: "2026-06-22", muscle: "front_delts" },
+      { weekStart: "2026-06-22", muscle: "triceps" },
+      { weekStart: "2026-06-29", muscle: "glutes" },
+      { weekStart: "2026-06-29", muscle: "quads" },
+    ]);
+  });
+
+  it("handles Japanese aliases through metadata", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([
+      createSet({ exerciseName: "スクワット" }),
+    ]);
+
+    expect(rows).toEqual([
+      {
+        weekStart: "2026-06-22",
+        muscle: "glutes",
+        totalSets: 1,
+        totalVolumeLoad: 500,
+        exercises: ["Squat"],
+      },
+      {
+        weekStart: "2026-06-22",
+        muscle: "quads",
+        totalSets: 1,
+        totalVolumeLoad: 500,
+        exercises: ["Squat"],
+      },
+    ]);
+  });
+
+  it("does not use secondary muscles", () => {
+    const rows = aggregateWeeklyMuscleGroupVolume([createSet()]);
+
+    expect(rows.some(({ muscle }) => muscle === "shoulders")).toBe(false);
+  });
+
+  it("does not mutate input", () => {
+    const input = [
+      createSet({ exerciseName: "ベンチプレス", tags: ["push"] }),
+    ];
+    const original = JSON.stringify(input);
+
+    aggregateWeeklyMuscleGroupVolume(input);
+
+    expect(JSON.stringify(input)).toBe(original);
+  });
+});

--- a/shared/utils/muscleGroupVolume.ts
+++ b/shared/utils/muscleGroupVolume.ts
@@ -1,0 +1,80 @@
+import { findExerciseMetadataByName } from "./exerciseCanonicalization";
+import type { NormalizedWorkoutSetWithMetrics } from "./trainingMetrics";
+import { getWeekStart } from "./weeklyTrainingVolume";
+
+export type WeeklyMuscleGroupVolumeRow = {
+  weekStart: string;
+  muscle: string;
+  totalSets: number;
+  totalVolumeLoad: number;
+  exercises: string[];
+};
+
+type WeeklyMuscleGroupVolumeAccumulator = {
+  weekStart: string;
+  muscle: string;
+  totalSets: number;
+  totalVolumeLoad: number;
+  exercises: Set<string>;
+};
+
+const isPositiveFiniteNumber = (
+  value: number | null | undefined
+): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value > 0
+);
+
+const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
+
+export const aggregateWeeklyMuscleGroupVolume = (
+  sets: NormalizedWorkoutSetWithMetrics[]
+): WeeklyMuscleGroupVolumeRow[] => {
+  if (!Array.isArray(sets) || sets.length === 0) {
+    return [];
+  }
+
+  const groups = new Map<string, WeeklyMuscleGroupVolumeAccumulator>();
+
+  sets.forEach((set) => {
+    const weekStart = getWeekStart(set.date);
+    const metadata = findExerciseMetadataByName(set.exerciseName);
+    if (!weekStart || !metadata) {
+      return;
+    }
+
+    const volumeLoad = set.metrics.volumeLoad;
+    const primaryMuscles = new Set(metadata.primaryMuscles);
+
+    primaryMuscles.forEach((muscle) => {
+      const key = `${weekStart}\u0000${muscle}`;
+      const group = groups.get(key) ?? {
+        weekStart,
+        muscle,
+        totalSets: 0,
+        totalVolumeLoad: 0,
+        exercises: new Set<string>(),
+      };
+
+      group.totalSets += 1;
+      if (isPositiveFiniteNumber(volumeLoad)) {
+        group.totalVolumeLoad += volumeLoad;
+      }
+      group.exercises.add(metadata.canonicalName);
+
+      groups.set(key, group);
+    });
+  });
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      weekStart: group.weekStart,
+      muscle: group.muscle,
+      totalSets: group.totalSets,
+      totalVolumeLoad: roundToTwoDecimals(group.totalVolumeLoad),
+      exercises: Array.from(group.exercises).sort((a, b) => a.localeCompare(b)),
+    }))
+    .sort((a, b) => {
+      const weekCompare = a.weekStart.localeCompare(b.weekStart);
+      return weekCompare !== 0 ? weekCompare : a.muscle.localeCompare(b.muscle);
+    });
+};


### PR DESCRIPTION
## Summary
- Added a pure weekly muscle group volume utility
- Uses exercise metadata `primaryMuscles` to aggregate weekly set count and volume load by muscle group
- Reuses Monday-start week calculation
- Excludes unmatched exercises and invalid dates
- Keeps unique sorted canonical exercise names for each muscle group
- Added tests for grouping, primary muscle allocation, volume handling, aliases, sorting, secondary muscle exclusion, and immutability
- Updated verification docs

## Verification
- `npm test` passed
  - 13 test suites passed
  - 127 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- This uses primary muscle volume only; secondary/indirect volume is intentionally out of scope
- Google Fonts download warning remains a known follow-up