### PR TITLE
Add training graph data utilities

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -40,6 +40,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared exercise metadata canonicalization tests are included in `npm test` and CI.
 - Shared BIG3 trend aggregation tests are included in `npm test` and CI.
 - Shared weekly muscle group volume aggregation tests are included in `npm test` and CI.
+- Shared training graph data transformation tests are included in `npm test` and CI.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -51,7 +52,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add graph data/UI integration, RPE/RIR input, and AI weekly summaries.
+- Add graph UI placement/integration, RPE/RIR input, and AI weekly summaries.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/trainingGraphData.spec.ts
+++ b/shared/utils/__tests__/trainingGraphData.spec.ts
@@ -1,0 +1,268 @@
+import type { Big3TrendSummary } from "../big3Trend";
+import type { WeeklyMuscleGroupVolumeRow } from "../muscleGroupVolume";
+import {
+  toBig3EstimatedOneRepMaxSeries,
+  toExerciseMetricSeries,
+  toMuscleGroupVolumeSeries,
+} from "../trainingGraphData";
+import type { NormalizedWorkoutSetWithMetrics } from "../trainingMetrics";
+
+type SetOverrides = Partial<Omit<NormalizedWorkoutSetWithMetrics, "metrics">> & {
+  metrics?: Partial<NormalizedWorkoutSetWithMetrics["metrics"]>;
+};
+
+const createSet = (overrides: SetOverrides = {}): NormalizedWorkoutSetWithMetrics => {
+  const { metrics, ...rest } = overrides;
+
+  return {
+    date: "2026-06-23",
+    userId: "user-1",
+    exerciseName: "Bench Press",
+    exerciseNote: null,
+    setIndex: 0,
+    weight: 100,
+    reps: 5,
+    restSeconds: 180,
+    rpe: null,
+    rir: null,
+    failure: null,
+    tags: [],
+    metrics: {
+      volumeLoad: 500,
+      estimatedOneRepMax: 116.67,
+      ...metrics,
+    },
+    ...rest,
+  };
+};
+
+const createBig3Summaries = (): Big3TrendSummary[] => [
+  {
+    liftType: "squat",
+    points: [],
+    maxEstimatedOneRepMax: null,
+    latestTopSet: null,
+  },
+  {
+    liftType: "bench",
+    points: [
+      {
+        date: "2026-06-12",
+        liftType: "bench",
+        exerciseName: "Competition Bench",
+        setIndex: 0,
+        weight: 105,
+        reps: 3,
+        estimatedOneRepMax: 115.5,
+        volumeLoad: 315,
+      },
+      {
+        date: "2026-06-10",
+        liftType: "bench",
+        exerciseName: "Bench Press",
+        setIndex: 0,
+        weight: 100,
+        reps: 5,
+        estimatedOneRepMax: 116.67,
+        volumeLoad: 500,
+      },
+    ],
+    maxEstimatedOneRepMax: null,
+    latestTopSet: null,
+  },
+  {
+    liftType: "deadlift",
+    points: [],
+    maxEstimatedOneRepMax: null,
+    latestTopSet: null,
+  },
+];
+
+describe("toBig3EstimatedOneRepMaxSeries", () => {
+  it("returns squat, bench, and deadlift series including empty series", () => {
+    const series = toBig3EstimatedOneRepMaxSeries(createBig3Summaries());
+
+    expect(series.map(({ id, label }) => ({ id, label }))).toEqual([
+      { id: "squat", label: "Squat" },
+      { id: "bench", label: "Bench Press" },
+      { id: "deadlift", label: "Deadlift" },
+    ]);
+    expect(series[0].points).toEqual([]);
+    expect(series[2].points).toEqual([]);
+  });
+
+  it("converts e1RM points and sorts them by x", () => {
+    const bench = toBig3EstimatedOneRepMaxSeries(createBig3Summaries())[1];
+
+    expect(bench.points).toEqual([
+      { x: "2026-06-10", y: 116.67, label: "Bench Press" },
+      { x: "2026-06-12", y: 115.5, label: "Competition Bench" },
+    ]);
+  });
+
+  it("excludes invalid e1RM values", () => {
+    const summaries = createBig3Summaries();
+    summaries[1].points.push(
+      { ...summaries[1].points[0], estimatedOneRepMax: null },
+      { ...summaries[1].points[0], estimatedOneRepMax: 0 },
+      { ...summaries[1].points[0], estimatedOneRepMax: Number.NaN },
+      { ...summaries[1].points[0], estimatedOneRepMax: Number.POSITIVE_INFINITY }
+    );
+
+    expect(toBig3EstimatedOneRepMaxSeries(summaries)[1].points).toHaveLength(2);
+  });
+});
+
+describe("toMuscleGroupVolumeSeries", () => {
+  const rows: WeeklyMuscleGroupVolumeRow[] = [
+    {
+      weekStart: "2026-06-29",
+      muscle: "chest",
+      totalSets: 4,
+      totalVolumeLoad: 2000,
+      exercises: ["Bench Press"],
+    },
+    {
+      weekStart: "2026-06-22",
+      muscle: "chest",
+      totalSets: 3,
+      totalVolumeLoad: 1500,
+      exercises: ["Bench Press"],
+    },
+    {
+      weekStart: "2026-06-22",
+      muscle: "back",
+      totalSets: 5,
+      totalVolumeLoad: 2400,
+      exercises: ["Barbell Row"],
+    },
+  ];
+
+  it("groups by muscle, uses totalSets by default, and sorts series and points", () => {
+    expect(toMuscleGroupVolumeSeries(rows)).toEqual([
+      {
+        id: "back",
+        label: "back",
+        points: [{ x: "2026-06-22", y: 5 }],
+      },
+      {
+        id: "chest",
+        label: "chest",
+        points: [
+          { x: "2026-06-22", y: 3 },
+          { x: "2026-06-29", y: 4 },
+        ],
+      },
+    ]);
+  });
+
+  it("supports totalVolumeLoad", () => {
+    const chest = toMuscleGroupVolumeSeries(rows, "totalVolumeLoad")
+      .find(({ id }) => id === "chest");
+
+    expect(chest?.points).toEqual([
+      { x: "2026-06-22", y: 1500 },
+      { x: "2026-06-29", y: 2000 },
+    ]);
+  });
+
+  it("allows zero and excludes invalid numeric values", () => {
+    const invalidRows: WeeklyMuscleGroupVolumeRow[] = [
+      { ...rows[0], weekStart: "2026-06-01", totalSets: 0 },
+      { ...rows[0], weekStart: "2026-06-08", totalSets: -1 },
+      { ...rows[0], weekStart: "2026-06-15", totalSets: Number.NaN },
+      { ...rows[0], weekStart: "2026-06-22", totalSets: Number.POSITIVE_INFINITY },
+    ];
+
+    expect(toMuscleGroupVolumeSeries(invalidRows)[0].points).toEqual([
+      { x: "2026-06-01", y: 0 },
+    ]);
+  });
+});
+
+describe("toExerciseMetricSeries", () => {
+  it("filters by exact exerciseName", () => {
+    const series = toExerciseMetricSeries([
+      createSet({ exerciseName: "Bench Press" }),
+      createSet({ exerciseName: "bench press", metrics: { estimatedOneRepMax: 120 } }),
+      createSet({ exerciseName: "Squat", metrics: { estimatedOneRepMax: 150 } }),
+    ], "Bench Press", "estimatedOneRepMax");
+
+    expect(series.points).toEqual([{ x: "2026-06-23", y: 116.67 }]);
+  });
+
+  it.each([
+    ["estimatedOneRepMax", 116.67],
+    ["volumeLoad", 500],
+    ["weight", 100],
+    ["reps", 5],
+  ] as const)("supports the %s metric", (metric, expected) => {
+    const series = toExerciseMetricSeries([createSet()], "Bench Press", metric);
+
+    expect(series.points).toEqual([{ x: "2026-06-23", y: expected }]);
+  });
+
+  it("excludes invalid dates", () => {
+    const series = toExerciseMetricSeries([
+      createSet({ date: "not-a-date" }),
+      createSet({ date: "2026-02-30" }),
+      createSet({ date: null }),
+      createSet({ date: "" }),
+      createSet({ date: "2026-06-23" }),
+    ], "Bench Press", "weight");
+
+    expect(series.points).toHaveLength(1);
+  });
+
+  it("excludes invalid numeric values", () => {
+    const series = toExerciseMetricSeries([
+      createSet({ weight: null }),
+      createSet({ weight: 0 }),
+      createSet({ weight: -1 }),
+      createSet({ weight: Number.NaN }),
+      createSet({ weight: Number.POSITIVE_INFINITY }),
+      createSet({ weight: 100 }),
+    ], "Bench Press", "weight");
+
+    expect(series.points).toEqual([{ x: "2026-06-23", y: 100 }]);
+  });
+
+  it("sorts by date and then setIndex", () => {
+    const series = toExerciseMetricSeries([
+      createSet({ date: "2026-06-25", setIndex: 0, weight: 105 }),
+      createSet({ date: "2026-06-23", setIndex: 2, weight: 102.5 }),
+      createSet({ date: "2026-06-23", setIndex: 1, weight: 100 }),
+    ], "Bench Press", "weight");
+
+    expect(series.points).toEqual([
+      { x: "2026-06-23", y: 100 },
+      { x: "2026-06-23", y: 102.5 },
+      { x: "2026-06-25", y: 105 },
+    ]);
+  });
+
+  it("returns empty points when no exercise matches", () => {
+    expect(
+      toExerciseMetricSeries([createSet()], "Squat", "weight")
+    ).toEqual({
+      id: "Squat:weight",
+      label: "Squat weight",
+      points: [],
+    });
+  });
+
+  it("creates a safely encoded series id", () => {
+    expect(
+      toExerciseMetricSeries([], "Bench Press", "weight").id
+    ).toBe("Bench%20Press:weight");
+  });
+
+  it("does not mutate input", () => {
+    const input = [createSet({ tags: ["push"] })];
+    const original = JSON.stringify(input);
+
+    toExerciseMetricSeries(input, "Bench Press", "estimatedOneRepMax");
+
+    expect(JSON.stringify(input)).toBe(original);
+  });
+});

--- a/shared/utils/trainingGraphData.ts
+++ b/shared/utils/trainingGraphData.ts
@@ -1,0 +1,177 @@
+import type {
+  Big3LiftType,
+  Big3TrendSummary,
+} from "./big3Trend";
+import type { WeeklyMuscleGroupVolumeRow } from "./muscleGroupVolume";
+import type { NormalizedWorkoutSetWithMetrics } from "./trainingMetrics";
+
+export type ChartDataPoint = {
+  x: string;
+  y: number;
+  label?: string;
+};
+
+export type ChartSeries = {
+  id: string;
+  label: string;
+  points: ChartDataPoint[];
+};
+
+export type MuscleGroupVolumeMetric = "totalSets" | "totalVolumeLoad";
+
+export type ExerciseMetric =
+  | "estimatedOneRepMax"
+  | "volumeLoad"
+  | "weight"
+  | "reps";
+
+const BIG3_LABELS: Record<Big3LiftType, string> = {
+  squat: "Squat",
+  bench: "Bench Press",
+  deadlift: "Deadlift",
+};
+
+const isPositiveFiniteNumber = (
+  value: number | null | undefined
+): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value > 0
+);
+
+const isNonNegativeFiniteNumber = (
+  value: number | null | undefined
+): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value >= 0
+);
+
+const getValidDate = (date: string | null | undefined): string | null => {
+  if (!date || date.trim() === "") {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const dayOfMonth = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, monthIndex, dayOfMonth));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== dayOfMonth
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+const getExerciseMetricValue = (
+  set: NormalizedWorkoutSetWithMetrics,
+  metric: ExerciseMetric
+): number | null => {
+  switch (metric) {
+    case "estimatedOneRepMax":
+      return set.metrics.estimatedOneRepMax;
+    case "volumeLoad":
+      return set.metrics.volumeLoad;
+    case "weight":
+      return set.weight;
+    case "reps":
+      return set.reps;
+  }
+};
+
+export const toBig3EstimatedOneRepMaxSeries = (
+  summaries: Big3TrendSummary[]
+): ChartSeries[] => {
+  if (!Array.isArray(summaries)) {
+    return [];
+  }
+
+  return summaries.map((summary) => ({
+    id: summary.liftType,
+    label: BIG3_LABELS[summary.liftType],
+    points: summary.points
+      .filter((point) => isPositiveFiniteNumber(point.estimatedOneRepMax))
+      .map((point) => ({
+        x: point.date,
+        y: point.estimatedOneRepMax as number,
+        label: point.exerciseName,
+      }))
+      .sort((a, b) => a.x.localeCompare(b.x)),
+  }));
+};
+
+export const toMuscleGroupVolumeSeries = (
+  rows: WeeklyMuscleGroupVolumeRow[],
+  metric: MuscleGroupVolumeMetric = "totalSets"
+): ChartSeries[] => {
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  const pointsByMuscle = new Map<string, ChartDataPoint[]>();
+
+  rows.forEach((row) => {
+    const points = pointsByMuscle.get(row.muscle) ?? [];
+    const value = row[metric];
+
+    if (isNonNegativeFiniteNumber(value)) {
+      points.push({
+        x: row.weekStart,
+        y: value,
+      });
+    }
+
+    pointsByMuscle.set(row.muscle, points);
+  });
+
+  return Array.from(pointsByMuscle.entries())
+    .map(([muscle, points]) => ({
+      id: muscle,
+      label: muscle,
+      points: [...points].sort((a, b) => a.x.localeCompare(b.x)),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+};
+
+export const toExerciseMetricSeries = (
+  sets: NormalizedWorkoutSetWithMetrics[],
+  exerciseName: string,
+  metric: ExerciseMetric
+): ChartSeries => {
+  const points = Array.isArray(sets)
+    ? sets
+      .filter((set) => set.exerciseName === exerciseName)
+      .flatMap((set) => {
+        const date = getValidDate(set.date);
+        const value = getExerciseMetricValue(set, metric);
+        if (!date || !isPositiveFiniteNumber(value)) {
+          return [];
+        }
+
+        return [{
+          point: {
+            x: date,
+            y: value,
+          },
+          setIndex: set.setIndex,
+        }];
+      })
+      .sort((a, b) => {
+        const dateCompare = a.point.x.localeCompare(b.point.x);
+        return dateCompare !== 0 ? dateCompare : a.setIndex - b.setIndex;
+      })
+      .map(({ point }) => point)
+    : [];
+
+  return {
+    id: `${encodeURIComponent(exerciseName)}:${metric}`,
+    label: `${exerciseName} ${metric}`,
+    points,
+  };
+};


### PR DESCRIPTION
## Summary
- Added pure training graph data utilities
- Converts BIG3 estimated 1RM trends into chart series
- Converts weekly muscle group volume rows into chart series
- Converts exercise-level estimated 1RM, volume load, weight, and reps into chart series
- Filters invalid dates and invalid numeric values
- Added tests for BIG3 series, muscle group volume series, exercise metric series, sorting, invalid values, empty states, and immutability
- Updated verification docs

## Verification
- `npm test` passed
  - 14 test suites passed
  - 144 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed

## Notes
- No DB changes
- No API changes
- No UI changes
- No dependency updates
- `package-lock.json` files were not changed
- Google Fonts download warning remains a known follow-up