### PR TITLE
Add analytics page scaffold

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -41,6 +41,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared BIG3 trend aggregation tests are included in `npm test` and CI.
 - Shared weekly muscle group volume aggregation tests are included in `npm test` and CI.
 - Shared training graph data transformation tests are included in `npm test` and CI.
+- The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
+- Analytics currently uses cards and tables; no graph library has been added.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -52,7 +54,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add graph UI placement/integration, RPE/RIR input, and AI weekly summaries.
+- Add full BIG3 and muscle-group graph rendering, RPE/RIR input, and AI weekly summaries.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/AnalyticsRangeFilter.tsx
+++ b/frontend/features/analytics/components/AnalyticsRangeFilter.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Button, Flex } from "@chakra-ui/react";
+
+export type AnalyticsRange = "4w" | "8w" | "12w" | "6m" | "all";
+
+type AnalyticsRangeFilterProps = {
+  value: AnalyticsRange;
+  onChange: (range: AnalyticsRange) => void;
+  isDisabled?: boolean;
+};
+
+const RANGE_OPTIONS: Array<{ value: AnalyticsRange; label: string }> = [
+  { value: "4w", label: "4 weeks" },
+  { value: "8w", label: "8 weeks" },
+  { value: "12w", label: "12 weeks" },
+  { value: "6m", label: "6 months" },
+  { value: "all", label: "All" },
+];
+
+const AnalyticsRangeFilter: React.FC<AnalyticsRangeFilterProps> = ({
+  value,
+  onChange,
+  isDisabled = false,
+}) => (
+  <Flex role="group" aria-label="Analytics date range" gap={2} wrap="wrap">
+    {RANGE_OPTIONS.map((option) => {
+      const isSelected = option.value === value;
+
+      return (
+        <Button
+          key={option.value}
+          size="sm"
+          minW="76px"
+          borderRadius="4px"
+          colorScheme={isSelected ? "teal" : "gray"}
+          variant={isSelected ? "solid" : "outline"}
+          aria-pressed={isSelected}
+          isDisabled={isDisabled}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </Button>
+      );
+    })}
+  </Flex>
+);
+
+export default AnalyticsRangeFilter;

--- a/frontend/features/analytics/components/Big3SummarySection.tsx
+++ b/frontend/features/analytics/components/Big3SummarySection.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+  Badge,
+  Box,
+  Heading,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import type { Big3TrendSummary } from "../../../../shared/utils/big3Trend";
+import type { ChartSeries } from "../../../../shared/utils/trainingGraphData";
+
+type Big3SummarySectionProps = {
+  summaries: Big3TrendSummary[];
+  series: ChartSeries[];
+};
+
+const LIFT_COLORS = {
+  squat: "green",
+  bench: "blue",
+  deadlift: "orange",
+} as const;
+
+const formatNumber = (value: number | null): string => {
+  if (value === null) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+const Big3SummarySection: React.FC<Big3SummarySectionProps> = ({
+  summaries,
+  series,
+}) => {
+  const seriesByLift = new Map(series.map((item) => [item.id, item]));
+
+  return (
+    <Box as="section" aria-labelledby="big3-heading">
+      <Heading id="big3-heading" as="h2" size="md" mb={4}>
+        BIG3
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+        {summaries.map((summary) => {
+          const latest = summary.latestTopSet;
+          const personalBest = summary.maxEstimatedOneRepMax;
+          const chartSeries = seriesByLift.get(summary.liftType);
+
+          return (
+            <Box
+              key={summary.liftType}
+              border="1px solid"
+              borderColor="gray.200"
+              borderRadius="6px"
+              p={4}
+              minH="220px"
+            >
+              <Stack spacing={4}>
+                <Box>
+                  <Badge colorScheme={LIFT_COLORS[summary.liftType]} mb={2}>
+                    {summary.liftType}
+                  </Badge>
+                  <Heading as="h3" size="sm">
+                    {chartSeries?.label ?? summary.liftType}
+                  </Heading>
+                </Box>
+
+                {latest ? (
+                  <Stack spacing={1}>
+                    <Text fontSize="xs" color="gray.500" textTransform="uppercase">
+                      Latest top set
+                    </Text>
+                    <Text fontWeight="semibold">{latest.exerciseName}</Text>
+                    <Text fontSize="sm" color="gray.600">
+                      {latest.date} | {formatNumber(latest.weight)} x {formatNumber(latest.reps)}
+                    </Text>
+                    <Text fontSize="sm">
+                      Estimated 1RM: {formatNumber(latest.estimatedOneRepMax)}
+                    </Text>
+                  </Stack>
+                ) : (
+                  <Text color="gray.500">No data yet</Text>
+                )}
+
+                {personalBest && (
+                  <Box borderTop="1px solid" borderColor="gray.100" pt={3}>
+                    <Text fontSize="xs" color="gray.500" textTransform="uppercase">
+                      Best estimated 1RM
+                    </Text>
+                    <Text fontWeight="semibold">
+                      {formatNumber(personalBest.estimatedOneRepMax)}
+                    </Text>
+                    <Text fontSize="sm" color="gray.600">
+                      {personalBest.date}
+                    </Text>
+                  </Box>
+                )}
+
+                <Text fontSize="xs" color="gray.500">
+                  {chartSeries?.points.length ?? 0} recorded points
+                </Text>
+              </Stack>
+            </Box>
+          );
+        })}
+      </SimpleGrid>
+    </Box>
+  );
+};
+
+export default Big3SummarySection;

--- a/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
+++ b/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from "react";
+import {
+  Box,
+  Heading,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+import type { WeeklyMuscleGroupVolumeRow } from "../../../../shared/utils/muscleGroupVolume";
+import type { ChartSeries } from "../../../../shared/utils/trainingGraphData";
+
+type MuscleGroupSummarySectionProps = {
+  rows: WeeklyMuscleGroupVolumeRow[];
+  series: ChartSeries[];
+};
+
+const MAX_VISIBLE_ROWS = 24;
+
+const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+}).format(value);
+
+const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
+  rows,
+  series,
+}) => {
+  const visibleRows = useMemo(
+    () => [...rows]
+      .sort((a, b) => {
+        const weekCompare = b.weekStart.localeCompare(a.weekStart);
+        return weekCompare !== 0 ? weekCompare : a.muscle.localeCompare(b.muscle);
+      })
+      .slice(0, MAX_VISIBLE_ROWS),
+    [rows]
+  );
+
+  return (
+    <Box as="section" aria-labelledby="muscle-groups-heading">
+      <Box mb={4}>
+        <Heading id="muscle-groups-heading" as="h2" size="md">
+          Muscle Groups
+        </Heading>
+        <Text mt={1} fontSize="sm" color="gray.600">
+          {series.length} tracked muscle groups
+        </Text>
+      </Box>
+
+      {visibleRows.length === 0 ? (
+        <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
+          <Text color="gray.500">No data yet</Text>
+        </Box>
+      ) : (
+        <TableContainer border="1px solid" borderColor="gray.200" borderRadius="6px">
+          <Table size="sm" variant="simple">
+            <Thead bg="gray.50">
+              <Tr>
+                <Th whiteSpace="nowrap">Week start</Th>
+                <Th>Muscle</Th>
+                <Th isNumeric>Total sets</Th>
+                <Th isNumeric>Total volume load</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {visibleRows.map((row) => (
+                <Tr key={`${row.weekStart}:${row.muscle}`}>
+                  <Td whiteSpace="nowrap">{row.weekStart}</Td>
+                  <Td textTransform="capitalize">{row.muscle.replaceAll("_", " ")}</Td>
+                  <Td isNumeric>{row.totalSets}</Td>
+                  <Td isNumeric>{formatNumber(row.totalVolumeLoad)}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default MuscleGroupSummarySection;

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Box,
+  Button,
+  Center,
+  Flex,
+  Heading,
+  IconButton,
+  Spinner,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+} from "@chakra-ui/react";
+import { CloseIcon, RepeatIcon } from "@chakra-ui/icons";
+import { useRouter } from "next/router";
+import { URLS } from "../../../../shared/constants/urls";
+import { getToken } from "../../../../shared/utils/tokenUtils";
+import {
+  aggregateBig3Trend,
+  type Big3TrendSummary,
+} from "../../../../shared/utils/big3Trend";
+import {
+  aggregateWeeklyMuscleGroupVolume,
+  type WeeklyMuscleGroupVolumeRow,
+} from "../../../../shared/utils/muscleGroupVolume";
+import { normalizeWorkoutSets } from "../../../../shared/utils/normalizeWorkoutSets";
+import {
+  toBig3EstimatedOneRepMaxSeries,
+  toMuscleGroupVolumeSeries,
+} from "../../../../shared/utils/trainingGraphData";
+import { addTrainingMetricsToSet } from "../../../../shared/utils/trainingMetrics";
+import { fetchNotesInRangeAPI } from "../../notes/api";
+import AnalyticsRangeFilter, {
+  type AnalyticsRange,
+} from "../components/AnalyticsRangeFilter";
+import Big3SummarySection from "../components/Big3SummarySection";
+import MuscleGroupSummarySection from "../components/MuscleGroupSummarySection";
+
+type LoadStatus = "loading" | "success" | "error";
+
+const formatLocalDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const getDateRange = (range: AnalyticsRange): { start: string; end: string } => {
+  const endDate = new Date();
+  endDate.setHours(0, 0, 0, 0);
+  const startDate = new Date(endDate);
+
+  switch (range) {
+    case "4w":
+      startDate.setDate(startDate.getDate() - 27);
+      break;
+    case "8w":
+      startDate.setDate(startDate.getDate() - 55);
+      break;
+    case "12w":
+      startDate.setDate(startDate.getDate() - 83);
+      break;
+    case "6m":
+      startDate.setMonth(startDate.getMonth() - 6);
+      break;
+    case "all":
+      return { start: "1970-01-01", end: formatLocalDate(endDate) };
+  }
+
+  return {
+    start: formatLocalDate(startDate),
+    end: formatLocalDate(endDate),
+  };
+};
+
+const AnalyticsPage: React.FC = () => {
+  const router = useRouter();
+  const requestIdRef = useRef(0);
+  const [range, setRange] = useState<AnalyticsRange>("12w");
+  const [reloadKey, setReloadKey] = useState(0);
+  const [status, setStatus] = useState<LoadStatus>("loading");
+  const [noteCount, setNoteCount] = useState(0);
+  const [normalizedSetCount, setNormalizedSetCount] = useState(0);
+  const [big3Summaries, setBig3Summaries] = useState<Big3TrendSummary[]>(() =>
+    aggregateBig3Trend([])
+  );
+  const [muscleRows, setMuscleRows] = useState<WeeklyMuscleGroupVolumeRow[]>([]);
+
+  const dateRange = useMemo(() => getDateRange(range), [range]);
+  const big3Series = useMemo(
+    () => toBig3EstimatedOneRepMaxSeries(big3Summaries),
+    [big3Summaries]
+  );
+  const muscleSeries = useMemo(
+    () => toMuscleGroupVolumeSeries(muscleRows),
+    [muscleRows]
+  );
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.replace(URLS.LOGIN_PAGE);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setStatus("loading");
+
+    const loadAnalytics = async () => {
+      try {
+        const notes = await fetchNotesInRangeAPI(dateRange.start, dateRange.end);
+        const normalizedSets = normalizeWorkoutSets(notes);
+        const setsWithMetrics = normalizedSets.map(addTrainingMetricsToSet);
+
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+
+        setNoteCount(notes.length);
+        setNormalizedSetCount(normalizedSets.length);
+        setBig3Summaries(aggregateBig3Trend(setsWithMetrics));
+        setMuscleRows(aggregateWeeklyMuscleGroupVolume(setsWithMetrics));
+        setStatus("success");
+      } catch {
+        if (requestId === requestIdRef.current) {
+          setStatus("error");
+        }
+      }
+    };
+
+    loadAnalytics();
+
+    return () => {
+      if (requestId === requestIdRef.current) {
+        requestIdRef.current += 1;
+      }
+    };
+  }, [dateRange.end, dateRange.start, reloadKey, router]);
+
+  const hasAnalyticsData = big3Series.some((series) => series.points.length > 0)
+    || muscleRows.length > 0;
+
+  return (
+    <Box minH="100vh" bg="gray.50" py={{ base: 4, md: 8 }} px={{ base: 4, md: 6 }}>
+      <Box maxW="7xl" mx="auto">
+        <Flex align="flex-start" justify="space-between" gap={4} mb={6}>
+          <Box>
+            <Heading as="h1" size="lg">
+              Analytics
+            </Heading>
+            <Text mt={1} fontSize="sm" color="gray.600">
+              {dateRange.start} to {dateRange.end}
+            </Text>
+          </Box>
+          <IconButton
+            aria-label="Back to calendar"
+            icon={<CloseIcon />}
+            variant="ghost"
+            onClick={() => router.push(URLS.TOP_PAGE)}
+          />
+        </Flex>
+
+        <Box mb={6}>
+          <Text fontSize="sm" fontWeight="semibold" mb={2}>
+            Range
+          </Text>
+          <AnalyticsRangeFilter
+            value={range}
+            onChange={setRange}
+            isDisabled={status === "loading"}
+          />
+        </Box>
+
+        {status === "loading" && (
+          <Center minH="300px">
+            <Spinner size="lg" />
+          </Center>
+        )}
+
+        {status === "error" && (
+          <Alert status="error" variant="left-accent" alignItems="center">
+            <AlertIcon />
+            <AlertDescription flex="1">
+              Analytics data could not be loaded.
+            </AlertDescription>
+            <Button
+              size="sm"
+              leftIcon={<RepeatIcon />}
+              onClick={() => setReloadKey((current) => current + 1)}
+            >
+              Retry
+            </Button>
+          </Alert>
+        )}
+
+        {status === "success" && !hasAnalyticsData && (
+          <Box border="1px solid" borderColor="gray.200" bg="white" p={8} textAlign="center">
+            <Heading as="h2" size="sm" mb={2}>
+              No analytics data yet
+            </Heading>
+            <Text color="gray.600">
+              {noteCount === 0
+                ? "No workout notes were found in this range."
+                : `No supported BIG3 or muscle-group data was found across ${normalizedSetCount} sets.`}
+            </Text>
+          </Box>
+        )}
+
+        {status === "success" && hasAnalyticsData && (
+          <Tabs colorScheme="teal" variant="line" isLazy>
+            <TabList overflowX="auto" overflowY="hidden">
+              <Tab whiteSpace="nowrap">BIG3</Tab>
+              <Tab whiteSpace="nowrap">Muscle Groups</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel px={0} py={6}>
+                <Big3SummarySection summaries={big3Summaries} series={big3Series} />
+              </TabPanel>
+              <TabPanel px={0} py={6}>
+                <MuscleGroupSummarySection rows={muscleRows} series={muscleSeries} />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default AnalyticsPage;

--- a/frontend/features/top/components/TopPage.tsx
+++ b/frontend/features/top/components/TopPage.tsx
@@ -150,6 +150,11 @@ const Top: React.FC = () => {
             _active={{ transform: "scale(0.95)" }}
           />
           <MenuList>
+            <MenuItem onClick={() => router.push(URLS.ANALYTICS_PAGE)}>
+              <Box fontSize="lg" py={4}>
+                Analytics
+              </Box>
+            </MenuItem>
             <MenuItem onClick={() => router.push(URLS.USER_PAGE)}>
               <Box fontSize="lg" py={4}>
                 User

--- a/frontend/pages/analytics.tsx
+++ b/frontend/pages/analytics.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import AnalyticsPage from "../features/analytics/pages/AnalyticsPage";
+
+const AnalyticsRoute: React.FC = () => <AnalyticsPage />;
+
+export default AnalyticsRoute;

--- a/shared/constants/urls.ts
+++ b/shared/constants/urls.ts
@@ -2,6 +2,7 @@ export const URLS = {
   NOTE_NEW: (date: string) => `/note/new?date=${date}`,
   USER_PAGE: '/user',
   CONTACT_PAGE: '/contact',
+  ANALYTICS_PAGE: '/analytics',
   TOP_PAGE: '/top',
   FORGOT_PASSWORD_PAGE: '/forgot-password',
   LOGIN_PAGE: '/login',


### PR DESCRIPTION
## Summary
- Added `/analytics` route and Analytics page scaffold
- Added top menu navigation to Analytics
- Reused the existing authenticated notes range API
- Connected notes → normalized sets → metrics → BIG3 and muscle group analytics
- Added 4w / 8w / 12w / 6m / all range filter with 12w default
- Added BIG3 summary cards and muscle group summary table
- Added loading, error/retry, and no-data states
- Updated verification docs

## Verification
- `npm test` passed
  - 14 test suites passed
  - 144 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` was generated in the production build

## Notes
- No DB changes
- No backend API changes
- No chart library or UI dependency added
- No package-lock changes
- Google Fonts download warning remains a known follow-up