### PR TITLE
Add muscle group chart UI

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -43,7 +43,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training graph data transformation tests are included in `npm test` and CI.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
-- The Analytics muscle-group view still uses a table; broader graph UI is a future task.
+- Analytics uses Recharts for the weekly muscle-group set volume chart; the muscle-group table remains as exact-value fallback content.
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -56,7 +56,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add muscle-group graph rendering, RPE/RIR input, and AI weekly summaries.
+- Add volume-load chart options, exercise trend rendering, RPE/RIR input, and AI weekly summaries.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
+++ b/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import type { WeeklyMuscleGroupVolumeRow } from "../../../../shared/utils/muscleGroupVolume";
 import type { ChartSeries } from "../../../../shared/utils/trainingGraphData";
+import MuscleGroupVolumeChart from "./MuscleGroupVolumeChart";
 
 type MuscleGroupSummarySectionProps = {
   rows: WeeklyMuscleGroupVolumeRow[];
@@ -48,6 +49,10 @@ const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
         <Text mt={1} fontSize="sm" color="gray.600">
           {series.length} tracked muscle groups
         </Text>
+      </Box>
+
+      <Box mb={6}>
+        <MuscleGroupVolumeChart series={series} />
       </Box>
 
       {visibleRows.length === 0 ? (

--- a/frontend/features/analytics/components/MuscleGroupVolumeChart.tsx
+++ b/frontend/features/analytics/components/MuscleGroupVolumeChart.tsx
@@ -1,0 +1,201 @@
+import React, { useMemo } from "react";
+import { Box, Heading, Text } from "@chakra-ui/react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { ChartSeries } from "../../../../shared/utils/trainingGraphData";
+
+type MuscleGroupVolumeChartProps = {
+  series: ChartSeries[];
+};
+
+type MuscleGroupChartRow = {
+  weekStart: string;
+} & Record<string, number | string | undefined>;
+
+type TooltipPayload = {
+  color?: string;
+  dataKey?: string | number;
+  name?: string | number;
+  value?: number | string;
+};
+
+type MuscleGroupTooltipProps = {
+  active?: boolean;
+  label?: string;
+  payload?: TooltipPayload[];
+};
+
+const MAX_VISIBLE_SERIES = 6;
+
+const SERIES_COLORS = [
+  "#2F855A",
+  "#2B6CB0",
+  "#C05621",
+  "#805AD5",
+  "#D53F8C",
+  "#718096",
+];
+
+const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+}).format(value);
+
+const isNonNegativeNumber = (value: number | string | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value >= 0
+);
+
+const toDisplayLabel = (value: string): string => value.replaceAll("_", " ");
+
+const getSeriesTotal = (series: ChartSeries): number => (
+  series.points.reduce((total, point) => (
+    isNonNegativeNumber(point.y) ? total + point.y : total
+  ), 0)
+);
+
+const getTopSeries = (series: ChartSeries[]): ChartSeries[] => (
+  [...series]
+    .filter((item) => item.points.some((point) => isNonNegativeNumber(point.y)))
+    .sort((a, b) => {
+      const totalCompare = getSeriesTotal(b) - getSeriesTotal(a);
+      return totalCompare !== 0 ? totalCompare : a.id.localeCompare(b.id);
+    })
+    .slice(0, MAX_VISIBLE_SERIES)
+);
+
+const toChartRows = (series: ChartSeries[]): MuscleGroupChartRow[] => {
+  const rowsByWeek = new Map<string, MuscleGroupChartRow>();
+
+  series.forEach((item) => {
+    item.points.forEach((point) => {
+      if (!isNonNegativeNumber(point.y)) {
+        return;
+      }
+
+      const row = rowsByWeek.get(point.x) ?? { weekStart: point.x };
+      row[item.id] = point.y;
+      rowsByWeek.set(point.x, row);
+    });
+  });
+
+  return Array.from(rowsByWeek.values()).sort((a, b) => (
+    a.weekStart.localeCompare(b.weekStart)
+  ));
+};
+
+const MuscleGroupTooltip: React.FC<MuscleGroupTooltipProps> = ({
+  active,
+  label,
+  payload,
+}) => {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="6px"
+      boxShadow="sm"
+      p={3}
+    >
+      <Text fontSize="sm" fontWeight="semibold" mb={2}>
+        {label}
+      </Text>
+      {payload.map((item) => {
+        const value = isNonNegativeNumber(item.value) ? item.value : null;
+        if (value === null) {
+          return null;
+        }
+
+        const name = typeof item.name === "string"
+          ? toDisplayLabel(item.name)
+          : String(item.name ?? "");
+
+        return (
+          <Text key={`${item.dataKey ?? name}`} color={item.color ?? "gray.700"} fontSize="sm">
+            {name}: {formatNumber(value)}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+};
+
+const MuscleGroupVolumeChart: React.FC<MuscleGroupVolumeChartProps> = ({
+  series,
+}) => {
+  const visibleSeries = useMemo(() => getTopSeries(series), [series]);
+  const chartRows = useMemo(() => toChartRows(visibleSeries), [visibleSeries]);
+
+  if (visibleSeries.length === 0 || chartRows.length === 0) {
+    return (
+      <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
+        <Text color="gray.500">No muscle group volume data yet</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      aria-label="Weekly muscle group set volume chart"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="6px"
+      bg="white"
+      p={{ base: 3, md: 4 }}
+    >
+      <Heading as="h3" size="sm" mb={1}>
+        Weekly Set Volume
+      </Heading>
+      <Text fontSize="sm" color="gray.600" mb={4}>
+        Top {visibleSeries.length} muscle groups by total sets in the selected range.
+      </Text>
+      <Box h={{ base: "300px", md: "380px" }} minW={0}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartRows} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="weekStart"
+              minTickGap={24}
+              tick={{ fontSize: 12 }}
+              tickMargin={8}
+            />
+            <YAxis
+              allowDecimals={false}
+              tick={{ fontSize: 12 }}
+              width={48}
+            />
+            <Tooltip content={<MuscleGroupTooltip />} />
+            <Legend
+              verticalAlign="top"
+              height={56}
+              formatter={(value) => toDisplayLabel(String(value))}
+              wrapperStyle={{ fontSize: "12px" }}
+            />
+            {visibleSeries.map((item, index) => (
+              <Bar
+                key={item.id}
+                dataKey={item.id}
+                name={item.label}
+                fill={SERIES_COLORS[index % SERIES_COLORS.length]}
+                maxBarSize={24}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+};
+
+export default MuscleGroupVolumeChart;


### PR DESCRIPTION
## Summary
- Added a Recharts weekly muscle group set volume chart to the Analytics page
- Displays the top 6 muscle groups by total sets in the selected range
- Keeps the existing muscle-group table as exact-value fallback content
- Added responsive chart container, tooltip, legend, empty state, and mobile-friendly height
- Updated verification docs

## Verification
- `npm test` passed
  - 14 test suites passed
  - 144 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` returned HTTP 200 on the dev server
- No new build warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No DB changes
- No backend API changes
- No backend service changes
- Muscle group chart currently uses total sets only
- Volume-load chart option is a future task
- Exercise trend selector, RPE/RIR input, and AI weekly summary remain future tasks