### PR TITLE
Update frontend TypeScript module resolution

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- Updated frontend TypeScript `moduleResolution` from `Node` to `Bundler`
- Resolved the TypeScript node10/moduleResolution deprecation warning
- Kept the change limited to `frontend/tsconfig.json`

## Verification
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `npm test` passed
  - 14 test suites passed
  - 144 tests passed
- `npm run build --prefix backend` passed

## Notes
- No package changes
- No package-lock changes
- No DB changes
- No API changes
- No UI changes
- Existing Google Fonts download warning remains a known follow-up