### PR TITLE
Add muscle group chart metric toggle

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -43,7 +43,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training graph data transformation tests are included in `npm test` and CI.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
-- Analytics uses Recharts for the weekly muscle-group set volume chart; the muscle-group table remains as exact-value fallback content.
+- Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -56,7 +56,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add volume-load chart options, exercise trend rendering, RPE/RIR input, and AI weekly summaries.
+- Add exercise trend rendering, RPE/RIR input, and AI weekly summaries.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
+++ b/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
@@ -1,6 +1,8 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Box,
+  Button,
+  Flex,
   Heading,
   Table,
   TableContainer,
@@ -12,15 +14,31 @@ import {
   Tr,
 } from "@chakra-ui/react";
 import type { WeeklyMuscleGroupVolumeRow } from "../../../../shared/utils/muscleGroupVolume";
-import type { ChartSeries } from "../../../../shared/utils/trainingGraphData";
+import {
+  toMuscleGroupVolumeSeries,
+  type MuscleGroupVolumeMetric,
+} from "../../../../shared/utils/trainingGraphData";
 import MuscleGroupVolumeChart from "./MuscleGroupVolumeChart";
 
 type MuscleGroupSummarySectionProps = {
   rows: WeeklyMuscleGroupVolumeRow[];
-  series: ChartSeries[];
 };
 
 const MAX_VISIBLE_ROWS = 24;
+
+const METRIC_OPTIONS: Array<{
+  label: string;
+  value: MuscleGroupVolumeMetric;
+}> = [
+  {
+    label: "Sets",
+    value: "totalSets",
+  },
+  {
+    label: "Volume Load",
+    value: "totalVolumeLoad",
+  },
+];
 
 const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 2,
@@ -28,8 +46,8 @@ const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
 
 const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
   rows,
-  series,
 }) => {
+  const [metric, setMetric] = useState<MuscleGroupVolumeMetric>("totalSets");
   const visibleRows = useMemo(
     () => [...rows]
       .sort((a, b) => {
@@ -38,6 +56,10 @@ const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
       })
       .slice(0, MAX_VISIBLE_ROWS),
     [rows]
+  );
+  const series = useMemo(
+    () => toMuscleGroupVolumeSeries(rows, metric),
+    [metric, rows]
   );
 
   return (
@@ -51,8 +73,33 @@ const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
         </Text>
       </Box>
 
+      <Flex
+        aria-label="Muscle group chart metric"
+        gap={2}
+        mb={4}
+        role="group"
+        wrap="wrap"
+      >
+        {METRIC_OPTIONS.map((option) => {
+          const isSelected = option.value === metric;
+
+          return (
+            <Button
+              key={option.value}
+              aria-pressed={isSelected}
+              colorScheme={isSelected ? "teal" : "gray"}
+              onClick={() => setMetric(option.value)}
+              size="sm"
+              variant={isSelected ? "solid" : "outline"}
+            >
+              {option.label}
+            </Button>
+          );
+        })}
+      </Flex>
+
       <Box mb={6}>
-        <MuscleGroupVolumeChart series={series} />
+        <MuscleGroupVolumeChart metric={metric} series={series} />
       </Box>
 
       {visibleRows.length === 0 ? (

--- a/frontend/features/analytics/components/MuscleGroupVolumeChart.tsx
+++ b/frontend/features/analytics/components/MuscleGroupVolumeChart.tsx
@@ -10,9 +10,13 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { ChartSeries } from "../../../../shared/utils/trainingGraphData";
+import type {
+  ChartSeries,
+  MuscleGroupVolumeMetric,
+} from "../../../../shared/utils/trainingGraphData";
 
 type MuscleGroupVolumeChartProps = {
+  metric: MuscleGroupVolumeMetric;
   series: ChartSeries[];
 };
 
@@ -30,6 +34,7 @@ type TooltipPayload = {
 type MuscleGroupTooltipProps = {
   active?: boolean;
   label?: string;
+  metric: MuscleGroupVolumeMetric;
   payload?: TooltipPayload[];
 };
 
@@ -43,6 +48,29 @@ const SERIES_COLORS = [
   "#D53F8C",
   "#718096",
 ];
+
+const METRIC_LABELS: Record<MuscleGroupVolumeMetric, {
+  ariaLabel: string;
+  description: string;
+  title: string;
+  tooltipSuffix: string;
+  yAxisLabel: string;
+}> = {
+  totalSets: {
+    ariaLabel: "Weekly muscle group set volume chart",
+    description: "total sets",
+    title: "Weekly Set Volume",
+    tooltipSuffix: "sets",
+    yAxisLabel: "Sets",
+  },
+  totalVolumeLoad: {
+    ariaLabel: "Weekly muscle group volume load chart",
+    description: "total volume load",
+    title: "Weekly Volume Load",
+    tooltipSuffix: "volume load",
+    yAxisLabel: "Volume Load",
+  },
+};
 
 const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 2,
@@ -93,6 +121,7 @@ const toChartRows = (series: ChartSeries[]): MuscleGroupChartRow[] => {
 const MuscleGroupTooltip: React.FC<MuscleGroupTooltipProps> = ({
   active,
   label,
+  metric,
   payload,
 }) => {
   if (!active || !payload || payload.length === 0) {
@@ -123,7 +152,7 @@ const MuscleGroupTooltip: React.FC<MuscleGroupTooltipProps> = ({
 
         return (
           <Text key={`${item.dataKey ?? name}`} color={item.color ?? "gray.700"} fontSize="sm">
-            {name}: {formatNumber(value)}
+            {name}: {formatNumber(value)} {METRIC_LABELS[metric].tooltipSuffix}
           </Text>
         );
       })}
@@ -132,10 +161,12 @@ const MuscleGroupTooltip: React.FC<MuscleGroupTooltipProps> = ({
 };
 
 const MuscleGroupVolumeChart: React.FC<MuscleGroupVolumeChartProps> = ({
+  metric,
   series,
 }) => {
   const visibleSeries = useMemo(() => getTopSeries(series), [series]);
   const chartRows = useMemo(() => toChartRows(visibleSeries), [visibleSeries]);
+  const metricLabels = METRIC_LABELS[metric];
 
   if (visibleSeries.length === 0 || chartRows.length === 0) {
     return (
@@ -147,7 +178,7 @@ const MuscleGroupVolumeChart: React.FC<MuscleGroupVolumeChartProps> = ({
 
   return (
     <Box
-      aria-label="Weekly muscle group set volume chart"
+      aria-label={metricLabels.ariaLabel}
       border="1px solid"
       borderColor="gray.200"
       borderRadius="6px"
@@ -155,10 +186,10 @@ const MuscleGroupVolumeChart: React.FC<MuscleGroupVolumeChartProps> = ({
       p={{ base: 3, md: 4 }}
     >
       <Heading as="h3" size="sm" mb={1}>
-        Weekly Set Volume
+        {metricLabels.title}
       </Heading>
       <Text fontSize="sm" color="gray.600" mb={4}>
-        Top {visibleSeries.length} muscle groups by total sets in the selected range.
+        Top {visibleSeries.length} muscle groups by {metricLabels.description} in the selected range.
       </Text>
       <Box h={{ base: "300px", md: "380px" }} minW={0}>
         <ResponsiveContainer width="100%" height="100%">
@@ -171,11 +202,17 @@ const MuscleGroupVolumeChart: React.FC<MuscleGroupVolumeChartProps> = ({
               tickMargin={8}
             />
             <YAxis
-              allowDecimals={false}
+              allowDecimals={metric === "totalVolumeLoad"}
+              label={{
+                angle: -90,
+                position: "insideLeft",
+                value: metricLabels.yAxisLabel,
+              }}
               tick={{ fontSize: 12 }}
-              width={48}
+              tickFormatter={(value) => formatNumber(Number(value))}
+              width={72}
             />
-            <Tooltip content={<MuscleGroupTooltip />} />
+            <Tooltip content={<MuscleGroupTooltip metric={metric} />} />
             <Legend
               verticalAlign="top"
               height={56}

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -32,7 +32,6 @@ import {
 import { normalizeWorkoutSets } from "../../../../shared/utils/normalizeWorkoutSets";
 import {
   toBig3EstimatedOneRepMaxSeries,
-  toMuscleGroupVolumeSeries,
 } from "../../../../shared/utils/trainingGraphData";
 import { addTrainingMetricsToSet } from "../../../../shared/utils/trainingMetrics";
 import { fetchNotesInRangeAPI } from "../../notes/api";
@@ -96,10 +95,6 @@ const AnalyticsPage: React.FC = () => {
   const big3Series = useMemo(
     () => toBig3EstimatedOneRepMaxSeries(big3Summaries),
     [big3Summaries]
-  );
-  const muscleSeries = useMemo(
-    () => toMuscleGroupVolumeSeries(muscleRows),
-    [muscleRows]
   );
 
   useEffect(() => {
@@ -222,7 +217,7 @@ const AnalyticsPage: React.FC = () => {
                 <Big3SummarySection summaries={big3Summaries} series={big3Series} />
               </TabPanel>
               <TabPanel px={0} py={6}>
-                <MuscleGroupSummarySection rows={muscleRows} series={muscleSeries} />
+                <MuscleGroupSummarySection rows={muscleRows} />
               </TabPanel>
             </TabPanels>
           </Tabs>


### PR DESCRIPTION
## Summary
- Added a Muscle Groups chart metric toggle for `totalSets` and `totalVolumeLoad`
- Keeps `totalSets` as the default metric
- Updates chart title, y-axis, tooltip suffix, and top-6 muscle selection based on the selected metric
- Generates muscle-group chart series inside `MuscleGroupSummarySection`
- Keeps the existing muscle-group table as exact-value fallback content
- Updated verification docs

## Verification
- `npm test` passed
  - 14 test suites passed
  - 144 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` returned HTTP 200 on the dev server
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No DB changes
- No backend API changes
- No backend service changes
- Exercise trend selector, RPE/RIR input, and AI weekly summary remain future tasks