### PR TITLE
Add exercise trend selector

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -44,6 +44,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
+- Analytics includes an exercise trend selector using existing normalized set metrics, exact raw exercise names, and an exact-value table fallback.
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -56,7 +57,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add exercise trend rendering, RPE/RIR input, and AI weekly summaries.
+- Add RPE/RIR input, AI weekly summaries, exercise canonicalization improvements, and chart UX polish if needed.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/ExerciseTrendChart.tsx
+++ b/frontend/features/analytics/components/ExerciseTrendChart.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { Box, Heading, Text } from "@chakra-ui/react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type {
+  ChartSeries,
+  ExerciseMetric,
+} from "../../../../shared/utils/trainingGraphData";
+
+type ExerciseTrendChartProps = {
+  exerciseName: string;
+  metric: ExerciseMetric;
+  series: ChartSeries;
+};
+
+type ExerciseTrendTooltipPayload = {
+  color?: string;
+  value?: number | string;
+};
+
+type ExerciseTrendTooltipProps = {
+  active?: boolean;
+  label?: string;
+  metric: ExerciseMetric;
+  payload?: ExerciseTrendTooltipPayload[];
+};
+
+const METRIC_LABELS: Record<ExerciseMetric, {
+  ariaLabel: string;
+  title: string;
+  tooltipLabel: string;
+  yAxisLabel: string;
+}> = {
+  estimatedOneRepMax: {
+    ariaLabel: "Exercise estimated one rep max trend chart",
+    title: "Estimated 1RM Trend",
+    tooltipLabel: "Estimated 1RM",
+    yAxisLabel: "Estimated 1RM",
+  },
+  weight: {
+    ariaLabel: "Exercise weight trend chart",
+    title: "Weight Trend",
+    tooltipLabel: "Weight",
+    yAxisLabel: "Weight",
+  },
+  volumeLoad: {
+    ariaLabel: "Exercise volume load trend chart",
+    title: "Volume Load Trend",
+    tooltipLabel: "Volume Load",
+    yAxisLabel: "Volume Load",
+  },
+  reps: {
+    ariaLabel: "Exercise reps trend chart",
+    title: "Reps Trend",
+    tooltipLabel: "Reps",
+    yAxisLabel: "Reps",
+  },
+};
+
+const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+}).format(value);
+
+const toPositiveNumber = (value: number | string | undefined): number | null => {
+  const numericValue = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : null;
+};
+
+const ExerciseTrendTooltip: React.FC<ExerciseTrendTooltipProps> = ({
+  active,
+  label,
+  metric,
+  payload,
+}) => {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const value = toPositiveNumber(payload[0]?.value);
+  if (value === null) {
+    return null;
+  }
+
+  return (
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="6px"
+      boxShadow="sm"
+      p={3}
+    >
+      <Text fontSize="sm" fontWeight="semibold" mb={2}>
+        {label}
+      </Text>
+      <Text color={payload[0]?.color ?? "gray.700"} fontSize="sm">
+        {METRIC_LABELS[metric].tooltipLabel}: {formatNumber(value)}
+      </Text>
+    </Box>
+  );
+};
+
+const ExerciseTrendChart: React.FC<ExerciseTrendChartProps> = ({
+  exerciseName,
+  metric,
+  series,
+}) => {
+  const metricLabels = METRIC_LABELS[metric];
+  const points = series.points.map((point) => ({
+    date: point.x,
+    value: point.y,
+  }));
+
+  if (points.length === 0) {
+    return (
+      <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
+        <Text color="gray.500">No exercise trend data yet</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      aria-label={`${metricLabels.ariaLabel} for ${exerciseName}`}
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="6px"
+      bg="white"
+      p={{ base: 3, md: 4 }}
+    >
+      <Heading as="h3" size="sm" mb={1}>
+        {metricLabels.title}
+      </Heading>
+      <Text fontSize="sm" color="gray.600" mb={4}>
+        {exerciseName}
+      </Text>
+      <Box h={{ base: "280px", md: "360px" }} minW={0}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="date"
+              minTickGap={24}
+              tick={{ fontSize: 12 }}
+              tickMargin={8}
+            />
+            <YAxis
+              label={{
+                angle: -90,
+                position: "insideLeft",
+                value: metricLabels.yAxisLabel,
+              }}
+              tick={{ fontSize: 12 }}
+              tickFormatter={(value) => formatNumber(Number(value))}
+              width={72}
+            />
+            <Tooltip content={<ExerciseTrendTooltip metric={metric} />} />
+            <Line
+              type="monotone"
+              dataKey="value"
+              name={metricLabels.tooltipLabel}
+              stroke="#2B6CB0"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+              connectNulls={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+    </Box>
+  );
+};
+
+export default ExerciseTrendChart;

--- a/frontend/features/analytics/components/ExerciseTrendSection.tsx
+++ b/frontend/features/analytics/components/ExerciseTrendSection.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  Heading,
+  Select,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+import type { NormalizedWorkoutSetWithMetrics } from "../../../../shared/utils/trainingMetrics";
+import {
+  toExerciseMetricSeries,
+  type ChartSeries,
+  type ExerciseMetric,
+} from "../../../../shared/utils/trainingGraphData";
+import ExerciseTrendChart from "./ExerciseTrendChart";
+
+type ExerciseTrendSectionProps = {
+  sets: NormalizedWorkoutSetWithMetrics[];
+};
+
+type ExerciseOption = {
+  name: string;
+  setCount: number;
+};
+
+const MAX_VISIBLE_ROWS = 12;
+
+const METRIC_OPTIONS: Array<{
+  label: string;
+  value: ExerciseMetric;
+}> = [
+  {
+    label: "Estimated 1RM",
+    value: "estimatedOneRepMax",
+  },
+  {
+    label: "Weight",
+    value: "weight",
+  },
+  {
+    label: "Volume Load",
+    value: "volumeLoad",
+  },
+  {
+    label: "Reps",
+    value: "reps",
+  },
+];
+
+const METRIC_LABELS: Record<ExerciseMetric, string> = {
+  estimatedOneRepMax: "Estimated 1RM",
+  weight: "Weight",
+  volumeLoad: "Volume Load",
+  reps: "Reps",
+};
+
+const formatNumber = (value: number): string => new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+}).format(value);
+
+const getExerciseOptions = (
+  sets: NormalizedWorkoutSetWithMetrics[]
+): ExerciseOption[] => {
+  const countsByExercise = new Map<string, number>();
+
+  sets.forEach((set) => {
+    if (set.exerciseName.trim() === "") {
+      return;
+    }
+
+    countsByExercise.set(
+      set.exerciseName,
+      (countsByExercise.get(set.exerciseName) ?? 0) + 1
+    );
+  });
+
+  return Array.from(countsByExercise.entries())
+    .map(([name, setCount]) => ({ name, setCount }))
+    .sort((a, b) => {
+      const countCompare = b.setCount - a.setCount;
+      return countCompare !== 0 ? countCompare : a.name.localeCompare(b.name);
+    });
+};
+
+const getRecentRows = (series: ChartSeries): ChartSeries["points"] => (
+  [...series.points]
+    .sort((a, b) => b.x.localeCompare(a.x))
+    .slice(0, MAX_VISIBLE_ROWS)
+);
+
+const ExerciseTrendSection: React.FC<ExerciseTrendSectionProps> = ({
+  sets,
+}) => {
+  const exerciseOptions = useMemo(() => getExerciseOptions(sets), [sets]);
+  const [selectedExerciseName, setSelectedExerciseName] = useState("");
+  const [metric, setMetric] = useState<ExerciseMetric>("estimatedOneRepMax");
+
+  useEffect(() => {
+    if (exerciseOptions.length === 0) {
+      setSelectedExerciseName("");
+      return;
+    }
+
+    const hasSelectedExercise = exerciseOptions.some((option) => (
+      option.name === selectedExerciseName
+    ));
+
+    if (!hasSelectedExercise) {
+      setSelectedExerciseName(exerciseOptions[0].name);
+    }
+  }, [exerciseOptions, selectedExerciseName]);
+
+  const selectedSeries = useMemo(
+    () => selectedExerciseName === ""
+      ? {
+        id: "",
+        label: "",
+        points: [],
+      }
+      : toExerciseMetricSeries(sets, selectedExerciseName, metric),
+    [metric, selectedExerciseName, sets]
+  );
+  const recentRows = useMemo(() => getRecentRows(selectedSeries), [selectedSeries]);
+
+  if (exerciseOptions.length === 0) {
+    return (
+      <Box as="section" aria-labelledby="exercise-trend-heading">
+        <Heading id="exercise-trend-heading" as="h2" size="md" mb={4}>
+          Exercises
+        </Heading>
+        <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
+          <Text color="gray.500">No exercise trend data yet</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box as="section" aria-labelledby="exercise-trend-heading">
+      <Box mb={4}>
+        <Heading id="exercise-trend-heading" as="h2" size="md">
+          Exercises
+        </Heading>
+        <Text mt={1} fontSize="sm" color="gray.600">
+          {exerciseOptions.length} tracked exercises using exact exercise names.
+        </Text>
+      </Box>
+
+      <Flex align={{ base: "stretch", md: "end" }} direction={{ base: "column", md: "row" }} gap={4} mb={4}>
+        <FormControl maxW={{ base: "100%", md: "360px" }}>
+          <FormLabel fontSize="sm" fontWeight="semibold">
+            Exercise
+          </FormLabel>
+          <Select
+            aria-label="Select exercise trend"
+            value={selectedExerciseName}
+            onChange={(event) => setSelectedExerciseName(event.target.value)}
+          >
+            {exerciseOptions.map((option) => (
+              <option key={option.name} value={option.name}>
+                {option.name} ({option.setCount})
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Flex
+          aria-label="Exercise trend metric"
+          gap={2}
+          role="group"
+          wrap="wrap"
+        >
+          {METRIC_OPTIONS.map((option) => {
+            const isSelected = option.value === metric;
+
+            return (
+              <Button
+                key={option.value}
+                aria-pressed={isSelected}
+                colorScheme={isSelected ? "teal" : "gray"}
+                onClick={() => setMetric(option.value)}
+                size="sm"
+                variant={isSelected ? "solid" : "outline"}
+              >
+                {option.label}
+              </Button>
+            );
+          })}
+        </Flex>
+      </Flex>
+
+      <Box mb={6}>
+        <ExerciseTrendChart
+          exerciseName={selectedExerciseName}
+          metric={metric}
+          series={selectedSeries}
+        />
+      </Box>
+
+      {recentRows.length === 0 ? (
+        <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
+          <Text color="gray.500">
+            No exact values for {METRIC_LABELS[metric]} yet.
+          </Text>
+        </Box>
+      ) : (
+        <TableContainer border="1px solid" borderColor="gray.200" borderRadius="6px">
+          <Table size="sm" variant="simple">
+            <Thead bg="gray.50">
+              <Tr>
+                <Th whiteSpace="nowrap">Date</Th>
+                <Th>Metric</Th>
+                <Th isNumeric>Value</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {recentRows.map((point, index) => (
+                <Tr key={`${point.x}:${point.y}:${index}`}>
+                  <Td whiteSpace="nowrap">{point.x}</Td>
+                  <Td>{METRIC_LABELS[metric]}</Td>
+                  <Td isNumeric>{formatNumber(point.y)}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default ExerciseTrendSection;

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -33,12 +33,16 @@ import { normalizeWorkoutSets } from "../../../../shared/utils/normalizeWorkoutS
 import {
   toBig3EstimatedOneRepMaxSeries,
 } from "../../../../shared/utils/trainingGraphData";
-import { addTrainingMetricsToSet } from "../../../../shared/utils/trainingMetrics";
+import {
+  addTrainingMetricsToSet,
+  type NormalizedWorkoutSetWithMetrics,
+} from "../../../../shared/utils/trainingMetrics";
 import { fetchNotesInRangeAPI } from "../../notes/api";
 import AnalyticsRangeFilter, {
   type AnalyticsRange,
 } from "../components/AnalyticsRangeFilter";
 import Big3SummarySection from "../components/Big3SummarySection";
+import ExerciseTrendSection from "../components/ExerciseTrendSection";
 import MuscleGroupSummarySection from "../components/MuscleGroupSummarySection";
 
 type LoadStatus = "loading" | "success" | "error";
@@ -90,6 +94,7 @@ const AnalyticsPage: React.FC = () => {
     aggregateBig3Trend([])
   );
   const [muscleRows, setMuscleRows] = useState<WeeklyMuscleGroupVolumeRow[]>([]);
+  const [setsWithMetrics, setSetsWithMetrics] = useState<NormalizedWorkoutSetWithMetrics[]>([]);
 
   const dateRange = useMemo(() => getDateRange(range), [range]);
   const big3Series = useMemo(
@@ -118,6 +123,7 @@ const AnalyticsPage: React.FC = () => {
 
         setNoteCount(notes.length);
         setNormalizedSetCount(normalizedSets.length);
+        setSetsWithMetrics(setsWithMetrics);
         setBig3Summaries(aggregateBig3Trend(setsWithMetrics));
         setMuscleRows(aggregateWeeklyMuscleGroupVolume(setsWithMetrics));
         setStatus("success");
@@ -137,8 +143,10 @@ const AnalyticsPage: React.FC = () => {
     };
   }, [dateRange.end, dateRange.start, reloadKey, router]);
 
+  const hasExerciseData = setsWithMetrics.some((set) => set.exerciseName.trim() !== "");
   const hasAnalyticsData = big3Series.some((series) => series.points.length > 0)
-    || muscleRows.length > 0;
+    || muscleRows.length > 0
+    || hasExerciseData;
 
   return (
     <Box minH="100vh" bg="gray.50" py={{ base: 4, md: 8 }} px={{ base: 4, md: 6 }}>
@@ -201,7 +209,7 @@ const AnalyticsPage: React.FC = () => {
             <Text color="gray.600">
               {noteCount === 0
                 ? "No workout notes were found in this range."
-                : `No supported BIG3 or muscle-group data was found across ${normalizedSetCount} sets.`}
+                : `No supported analytics data was found across ${normalizedSetCount} sets.`}
             </Text>
           </Box>
         )}
@@ -211,6 +219,7 @@ const AnalyticsPage: React.FC = () => {
             <TabList overflowX="auto" overflowY="hidden">
               <Tab whiteSpace="nowrap">BIG3</Tab>
               <Tab whiteSpace="nowrap">Muscle Groups</Tab>
+              <Tab whiteSpace="nowrap">Exercises</Tab>
             </TabList>
             <TabPanels>
               <TabPanel px={0} py={6}>
@@ -218,6 +227,9 @@ const AnalyticsPage: React.FC = () => {
               </TabPanel>
               <TabPanel px={0} py={6}>
                 <MuscleGroupSummarySection rows={muscleRows} />
+              </TabPanel>
+              <TabPanel px={0} py={6}>
+                <ExerciseTrendSection sets={setsWithMetrics} />
               </TabPanel>
             </TabPanels>
           </Tabs>


### PR DESCRIPTION
## Summary
- Added an Exercises tab to the Analytics page
- Added one-exercise trend selection using exact raw exercise names
- Added metric toggle for Estimated 1RM, Weight, Volume Load, and Reps
- Added a Recharts line chart for the selected exercise metric
- Added an exact-value fallback table for recent points
- Updated verification docs

## Verification
- `npm test` passed
  - 14 test suites passed
  - 144 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` returned HTTP 200 on the dev server
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No DB changes
- No backend API changes
- No backend service changes
- Exercise trend currently uses exact raw exercise names
- Canonicalized exercise grouping, RPE/RIR input, and AI weekly summary remain future tasks