### PR TITLE
Add exercise trend canonical grouping helper

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -45,6 +45,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
 - Analytics includes an exercise trend selector using existing normalized set metrics, exact raw exercise names, and an exact-value table fallback.
+- Frontend analytics canonical exercise grouping helper tests are included in `npm test` and CI; the helper is not wired into the selector UI yet.
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -57,7 +58,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add RPE/RIR input, AI weekly summaries, exercise canonicalization improvements, and chart UX polish if needed.
+- Add Exercise trend canonical selector UI integration, RPE/RIR input, AI weekly summaries, and chart UX polish if needed.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/utils/__tests__/exerciseTrendCanonicalGrouping.spec.ts
+++ b/frontend/features/analytics/utils/__tests__/exerciseTrendCanonicalGrouping.spec.ts
@@ -1,0 +1,306 @@
+/// <reference types="jest" />
+
+import type { NormalizedWorkoutSetWithMetrics } from "../../../../../shared/utils/trainingMetrics";
+import type { ExerciseMetric } from "../../../../../shared/utils/trainingGraphData";
+import {
+  buildCanonicalExerciseTrendGroups,
+  type CanonicalExerciseTrendGroup,
+  toCanonicalExerciseMetricSeries,
+} from "../exerciseTrendCanonicalGrouping";
+
+const makeSet = (
+  overrides: Partial<NormalizedWorkoutSetWithMetrics> = {}
+): NormalizedWorkoutSetWithMetrics => ({
+  date: "2026-06-01",
+  exerciseName: "Bench Press",
+  exerciseNote: null,
+  failure: null,
+  metrics: {
+    estimatedOneRepMax: 116.67,
+    volumeLoad: 500,
+    ...(overrides.metrics ?? {}),
+  },
+  reps: 5,
+  restSeconds: null,
+  rir: null,
+  rpe: null,
+  setIndex: 0,
+  tags: [],
+  userId: "user-1",
+  weight: 100,
+  ...overrides,
+});
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+describe("buildCanonicalExerciseTrendGroups", () => {
+  it("returns an empty array for empty or non-array input", () => {
+    expect(buildCanonicalExerciseTrendGroups([])).toEqual([]);
+    expect(
+      buildCanonicalExerciseTrendGroups(undefined as unknown as NormalizedWorkoutSetWithMetrics[])
+    ).toEqual([]);
+  });
+
+  it("excludes empty exercise names", () => {
+    const groups = buildCanonicalExerciseTrendGroups([
+      makeSet({ exerciseName: "" }),
+      makeSet({ exerciseName: "   " }),
+    ]);
+
+    expect(groups).toEqual([]);
+  });
+
+  it("groups known bench aliases under Bench Press", () => {
+    const groups = buildCanonicalExerciseTrendGroups([
+      makeSet({ exerciseName: "Bench Press" }),
+      makeSet({ exerciseName: "bench press" }),
+      makeSet({ exerciseName: "ベンチプレス" }),
+      makeSet({ exerciseName: "Paused Bench Press" }),
+      makeSet({ exerciseName: "Competition Bench" }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toEqual({
+      canonicalName: "Bench Press",
+      groupName: "Bench Press",
+      isMetadataMatched: true,
+      rawExerciseNames: [
+        "Bench Press",
+        "bench press",
+        "ベンチプレス",
+        "Paused Bench Press",
+        "Competition Bench",
+      ].sort((a, b) => a.localeCompare(b)),
+      setCount: 5,
+    });
+  });
+
+  it("keeps unmatched exercises as trimmed raw-name groups", () => {
+    const groups = buildCanonicalExerciseTrendGroups([
+      makeSet({ exerciseName: "  Cable Fly  " }),
+    ]);
+
+    expect(groups).toEqual([{
+      canonicalName: null,
+      groupName: "Cable Fly",
+      isMetadataMatched: false,
+      rawExerciseNames: ["Cable Fly"],
+      setCount: 1,
+    }]);
+  });
+
+  it("keeps unique sorted raw names and sums set counts by group", () => {
+    const groups = buildCanonicalExerciseTrendGroups([
+      makeSet({ exerciseName: "Bench Press" }),
+      makeSet({ exerciseName: "bench press" }),
+      makeSet({ exerciseName: "bench press" }),
+      makeSet({ exerciseName: "  Cable Fly  " }),
+      makeSet({ exerciseName: "Cable Fly" }),
+    ]);
+
+    expect(groups).toEqual([
+      {
+        canonicalName: "Bench Press",
+        groupName: "Bench Press",
+        isMetadataMatched: true,
+        rawExerciseNames: ["bench press", "Bench Press"].sort((a, b) => a.localeCompare(b)),
+        setCount: 3,
+      },
+      {
+        canonicalName: null,
+        groupName: "Cable Fly",
+        isMetadataMatched: false,
+        rawExerciseNames: ["Cable Fly"],
+        setCount: 2,
+      },
+    ]);
+  });
+
+  it("sorts output by setCount desc and groupName asc", () => {
+    const groups = buildCanonicalExerciseTrendGroups([
+      makeSet({ exerciseName: "Z Curl" }),
+      makeSet({ exerciseName: "Bench Press" }),
+      makeSet({ exerciseName: "A Curl" }),
+      makeSet({ exerciseName: "bench press" }),
+    ]);
+
+    expect(groups.map((group) => group.groupName)).toEqual([
+      "Bench Press",
+      "A Curl",
+      "Z Curl",
+    ]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [
+      makeSet({ exerciseName: "  Cable Fly  " }),
+      makeSet({ exerciseName: "Bench Press" }),
+    ];
+    const original = clone(input);
+
+    buildCanonicalExerciseTrendGroups(input);
+
+    expect(input).toEqual(original);
+  });
+});
+
+describe("toCanonicalExerciseMetricSeries", () => {
+  const benchGroup: CanonicalExerciseTrendGroup = {
+    canonicalName: "Bench Press",
+    groupName: "Bench Press",
+    isMetadataMatched: true,
+    rawExerciseNames: ["Bench Press", "bench press", "ベンチプレス"],
+    setCount: 3,
+  };
+
+  it("combines points from multiple raw names in the selected canonical group", () => {
+    const series = toCanonicalExerciseMetricSeries([
+      makeSet({
+        date: "2026-06-08",
+        exerciseName: "bench press",
+        metrics: { estimatedOneRepMax: 120, volumeLoad: 520 },
+        setIndex: 1,
+      }),
+      makeSet({
+        date: "2026-06-01",
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: 110, volumeLoad: 500 },
+        setIndex: 0,
+      }),
+      makeSet({
+        date: "2026-06-08",
+        exerciseName: "ベンチプレス",
+        metrics: { estimatedOneRepMax: 118, volumeLoad: 510 },
+        setIndex: 0,
+      }),
+      makeSet({
+        date: "2026-06-01",
+        exerciseName: "Squat",
+        metrics: { estimatedOneRepMax: 150, volumeLoad: 600 },
+        setIndex: 0,
+      }),
+    ], benchGroup, "estimatedOneRepMax");
+
+    expect(series).toEqual({
+      id: "Bench%20Press:estimatedOneRepMax",
+      label: "Bench Press estimatedOneRepMax",
+      points: [
+        { x: "2026-06-01", y: 110, label: "Bench Press" },
+        { x: "2026-06-08", y: 118, label: "ベンチプレス" },
+        { x: "2026-06-08", y: 120, label: "bench press" },
+      ],
+    });
+  });
+
+  const metricCases: Array<[ExerciseMetric, number]> = [
+    ["estimatedOneRepMax", 116.67],
+    ["weight", 100],
+    ["volumeLoad", 500],
+    ["reps", 5],
+  ];
+
+  it.each(metricCases)("supports the %s metric", (metric, expectedValue) => {
+    const series = toCanonicalExerciseMetricSeries([
+      makeSet({ exerciseName: "Bench Press" }),
+    ], benchGroup, metric);
+
+    expect(series.points).toEqual([
+      { x: "2026-06-01", y: expectedValue, label: "Bench Press" },
+    ]);
+  });
+
+  it("excludes invalid dates and non-positive or non-finite metric values", () => {
+    const series = toCanonicalExerciseMetricSeries([
+      makeSet({ date: "2026-02-30", exerciseName: "Bench Press" }),
+      makeSet({ date: "", exerciseName: "Bench Press" }),
+      makeSet({
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: null, volumeLoad: 500 },
+      }),
+      makeSet({
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: 0, volumeLoad: 500 },
+      }),
+      makeSet({
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: -1, volumeLoad: 500 },
+      }),
+      makeSet({
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: Number.NaN, volumeLoad: 500 },
+      }),
+      makeSet({
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: Number.POSITIVE_INFINITY, volumeLoad: 500 },
+      }),
+      makeSet({
+        date: "2026-06-02",
+        exerciseName: "Bench Press",
+        metrics: { estimatedOneRepMax: 115, volumeLoad: 500 },
+      }),
+    ], benchGroup, "estimatedOneRepMax");
+
+    expect(series.points).toEqual([
+      { x: "2026-06-02", y: 115, label: "Bench Press" },
+    ]);
+  });
+
+  it("sorts by date asc and setIndex asc", () => {
+    const series = toCanonicalExerciseMetricSeries([
+      makeSet({ date: "2026-06-03", exerciseName: "Bench Press", setIndex: 0 }),
+      makeSet({ date: "2026-06-01", exerciseName: "Bench Press", setIndex: 1 }),
+      makeSet({ date: "2026-06-01", exerciseName: "bench press", setIndex: 0 }),
+    ], benchGroup, "weight");
+
+    expect(series.points).toEqual([
+      { x: "2026-06-01", y: 100, label: "bench press" },
+      { x: "2026-06-01", y: 100, label: "Bench Press" },
+      { x: "2026-06-03", y: 100, label: "Bench Press" },
+    ]);
+  });
+
+  it("builds a series for an unmatched raw group", () => {
+    const cableFlyGroup: CanonicalExerciseTrendGroup = {
+      canonicalName: null,
+      groupName: "Cable Fly",
+      isMetadataMatched: false,
+      rawExerciseNames: ["Cable Fly"],
+      setCount: 1,
+    };
+    const series = toCanonicalExerciseMetricSeries([
+      makeSet({
+        date: "2026-06-04",
+        exerciseName: "  Cable Fly  ",
+        metrics: { estimatedOneRepMax: 50, volumeLoad: 200 },
+        weight: 20,
+      }),
+    ], cableFlyGroup, "weight");
+
+    expect(series).toEqual({
+      id: "Cable%20Fly:weight",
+      label: "Cable Fly weight",
+      points: [
+        { x: "2026-06-04", y: 20, label: "Cable Fly" },
+      ],
+    });
+  });
+
+  it("returns empty points when there are no matching sets", () => {
+    const series = toCanonicalExerciseMetricSeries([
+      makeSet({ exerciseName: "Squat" }),
+    ], benchGroup, "estimatedOneRepMax");
+
+    expect(series.points).toEqual([]);
+  });
+
+  it("does not mutate input", () => {
+    const input = [
+      makeSet({ exerciseName: "Bench Press" }),
+    ];
+    const original = clone(input);
+
+    toCanonicalExerciseMetricSeries(input, benchGroup, "estimatedOneRepMax");
+
+    expect(input).toEqual(original);
+  });
+});

--- a/frontend/features/analytics/utils/exerciseTrendCanonicalGrouping.ts
+++ b/frontend/features/analytics/utils/exerciseTrendCanonicalGrouping.ts
@@ -1,0 +1,171 @@
+import { findExerciseMetadataByName } from "../../../../shared/utils/exerciseCanonicalization";
+import type { NormalizedWorkoutSetWithMetrics } from "../../../../shared/utils/trainingMetrics";
+import type {
+  ChartSeries,
+  ExerciseMetric,
+} from "../../../../shared/utils/trainingGraphData";
+
+export type CanonicalExerciseTrendGroup = {
+  groupName: string;
+  canonicalName: string | null;
+  rawExerciseNames: string[];
+  setCount: number;
+  isMetadataMatched: boolean;
+};
+
+export type CanonicalizedExerciseTrendPoint = {
+  date: string;
+  rawExerciseName: string;
+  canonicalName: string | null;
+  value: number;
+};
+
+type MutableCanonicalExerciseTrendGroup = {
+  canonicalName: string | null;
+  groupName: string;
+  isMetadataMatched: boolean;
+  rawExerciseNames: Set<string>;
+  setCount: number;
+};
+
+const getValidDate = (date: string | null | undefined): string | null => {
+  if (!date || date.trim() === "") {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const dayOfMonth = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, monthIndex, dayOfMonth));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== dayOfMonth
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+const getMetricValue = (
+  set: NormalizedWorkoutSetWithMetrics,
+  metric: ExerciseMetric
+): number | null => {
+  switch (metric) {
+    case "estimatedOneRepMax":
+      return set.metrics.estimatedOneRepMax;
+    case "weight":
+      return set.weight;
+    case "volumeLoad":
+      return set.metrics.volumeLoad;
+    case "reps":
+      return set.reps;
+  }
+};
+
+const isPositiveFiniteNumber = (
+  value: number | null | undefined
+): value is number => (
+  typeof value === "number" && Number.isFinite(value) && value > 0
+);
+
+export const buildCanonicalExerciseTrendGroups = (
+  sets: NormalizedWorkoutSetWithMetrics[]
+): CanonicalExerciseTrendGroup[] => {
+  if (!Array.isArray(sets) || sets.length === 0) {
+    return [];
+  }
+
+  const groupsByName = new Map<string, MutableCanonicalExerciseTrendGroup>();
+
+  sets.forEach((set) => {
+    const rawExerciseName = set.exerciseName.trim();
+    if (rawExerciseName === "") {
+      return;
+    }
+
+    const metadata = findExerciseMetadataByName(rawExerciseName);
+    const groupName = metadata?.canonicalName ?? rawExerciseName;
+    const existingGroup = groupsByName.get(groupName);
+    const group = existingGroup ?? {
+      canonicalName: metadata?.canonicalName ?? null,
+      groupName,
+      isMetadataMatched: Boolean(metadata),
+      rawExerciseNames: new Set<string>(),
+      setCount: 0,
+    };
+
+    group.rawExerciseNames.add(rawExerciseName);
+    group.setCount += 1;
+
+    if (metadata) {
+      group.canonicalName = metadata.canonicalName;
+      group.isMetadataMatched = true;
+    }
+
+    groupsByName.set(groupName, group);
+  });
+
+  return Array.from(groupsByName.values())
+    .map((group) => ({
+      canonicalName: group.canonicalName,
+      groupName: group.groupName,
+      isMetadataMatched: group.isMetadataMatched,
+      rawExerciseNames: Array.from(group.rawExerciseNames).sort((a, b) => a.localeCompare(b)),
+      setCount: group.setCount,
+    }))
+    .sort((a, b) => {
+      const countCompare = b.setCount - a.setCount;
+      return countCompare !== 0 ? countCompare : a.groupName.localeCompare(b.groupName);
+    });
+};
+
+export const toCanonicalExerciseMetricSeries = (
+  sets: NormalizedWorkoutSetWithMetrics[],
+  group: CanonicalExerciseTrendGroup,
+  metric: ExerciseMetric
+): ChartSeries => {
+  const rawExerciseNames = new Set(group.rawExerciseNames.map((name) => name.trim()));
+  const points = Array.isArray(sets)
+    ? sets
+      .flatMap((set) => {
+        const rawExerciseName = set.exerciseName.trim();
+        if (!rawExerciseNames.has(rawExerciseName)) {
+          return [];
+        }
+
+        const date = getValidDate(set.date);
+        const value = getMetricValue(set, metric);
+        if (!date || !isPositiveFiniteNumber(value)) {
+          return [];
+        }
+
+        return [{
+          point: {
+            x: date,
+            y: value,
+            label: rawExerciseName,
+          },
+          setIndex: set.setIndex,
+        }];
+      })
+      .sort((a, b) => {
+        const dateCompare = a.point.x.localeCompare(b.point.x);
+        return dateCompare !== 0 ? dateCompare : a.setIndex - b.setIndex;
+      })
+      .map(({ point }) => point)
+    : [];
+
+  return {
+    id: `${encodeURIComponent(group.groupName)}:${metric}`,
+    label: `${group.groupName} ${metric}`,
+    points,
+  };
+};


### PR DESCRIPTION
## Summary
- Added a pure canonical grouping helper for the Exercise trend selector
- Groups metadata-matched exercise names by canonicalName
- Keeps unmatched exercises as trimmed raw-name groups
- Preserves raw exercise names for future fallback table and tooltip use
- Added canonical exercise metric series generation for grouped raw names
- Added tests for grouping, metric series generation, invalid data handling, sorting, and mutation safety
- Updated verification docs

## Verification
- `npm test` passed
  - 15 test suites passed
  - 161 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No UI changes
- No DB changes
- No backend API changes
- No backend service changes
- Helper is not wired into the Exercise trend selector UI yet