### PR TITLE
Polish analytics chart UX

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -44,8 +44,9 @@ GitHub Actions runs the same baseline on push and pull request:
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
-- Analytics includes an exercise trend selector using existing normalized set metrics, canonical exercise groups when metadata matches, and an exact-value table fallback.
-- Analytics exercise trend selector uses canonical exercise groups when metadata matches; unmatched exercises remain raw-name groups and the fallback table shows raw exercise names.
+- Analytics includes an exercise trend selector using existing normalized set metrics and canonical exercise groups when metadata matches.
+- Analytics chart empty states are range-aware, and exact-value fallback tables remain available for BIG3, muscle groups, and exercise trends.
+- Unmatched exercise trends remain raw-name groups; exercise chart tooltips and fallback tables show raw exercise names.
 - Frontend analytics canonical exercise grouping helper tests are included in `npm test` and CI.
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
@@ -59,7 +60,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add RPE/RIR input, AI weekly summaries, DB-backed/custom exercise catalog exploration, and chart UX polish if needed.
+- Add RPE/RIR input, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/Big3EstimatedOneRepMaxChart.tsx
+++ b/frontend/features/analytics/components/Big3EstimatedOneRepMaxChart.tsx
@@ -156,7 +156,7 @@ const Big3EstimatedOneRepMaxChart: React.FC<Big3EstimatedOneRepMaxChartProps> = 
   if (chartRows.length === 0) {
     return (
       <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
-        <Text color="gray.500">No BIG3 trend data yet</Text>
+        <Text color="gray.500">No BIG3 estimated 1RM data in this range.</Text>
       </Box>
     );
   }

--- a/frontend/features/analytics/components/ExerciseTrendChart.tsx
+++ b/frontend/features/analytics/components/ExerciseTrendChart.tsx
@@ -22,6 +22,7 @@ type ExerciseTrendChartProps = {
 
 type ExerciseTrendTooltipPayload = {
   color?: string;
+  payload?: ExerciseTrendChartPoint;
   value?: number | string;
 };
 
@@ -30,6 +31,12 @@ type ExerciseTrendTooltipProps = {
   label?: string;
   metric: ExerciseMetric;
   payload?: ExerciseTrendTooltipPayload[];
+};
+
+type ExerciseTrendChartPoint = {
+  date: string;
+  exerciseName?: string;
+  value: number;
 };
 
 const METRIC_LABELS: Record<ExerciseMetric, {
@@ -103,6 +110,11 @@ const ExerciseTrendTooltip: React.FC<ExerciseTrendTooltipProps> = ({
       <Text color={payload[0]?.color ?? "gray.700"} fontSize="sm">
         {METRIC_LABELS[metric].tooltipLabel}: {formatNumber(value)}
       </Text>
+      {payload[0]?.payload?.exerciseName && (
+        <Text color="gray.600" fontSize="sm">
+          {payload[0].payload.exerciseName}
+        </Text>
+      )}
     </Box>
   );
 };
@@ -113,15 +125,16 @@ const ExerciseTrendChart: React.FC<ExerciseTrendChartProps> = ({
   series,
 }) => {
   const metricLabels = METRIC_LABELS[metric];
-  const points = series.points.map((point) => ({
+  const points: ExerciseTrendChartPoint[] = series.points.map((point) => ({
     date: point.x,
+    exerciseName: point.label,
     value: point.y,
   }));
 
   if (points.length === 0) {
     return (
       <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
-        <Text color="gray.500">No exercise trend data yet</Text>
+        <Text color="gray.500">No exercise trend data for the selected metric.</Text>
       </Box>
     );
   }
@@ -139,7 +152,7 @@ const ExerciseTrendChart: React.FC<ExerciseTrendChartProps> = ({
         {metricLabels.title}
       </Heading>
       <Text fontSize="sm" color="gray.600" mb={4}>
-        {exerciseName}
+        Selected group: {exerciseName}. Canonical metadata is used when available.
       </Text>
       <Box h={{ base: "280px", md: "360px" }} minW={0}>
         <ResponsiveContainer width="100%" height="100%">

--- a/frontend/features/analytics/components/ExerciseTrendSection.tsx
+++ b/frontend/features/analytics/components/ExerciseTrendSection.tsx
@@ -140,11 +140,16 @@ const ExerciseTrendSection: React.FC<ExerciseTrendSectionProps> = ({
           Exercises
         </Heading>
         <Text mt={1} fontSize="sm" color="gray.600">
-          {groups.length} exercise groups using canonical metadata when available.
+          {groups.length} exercise groups. Canonical metadata is used when available, and raw names stay visible in the table.
         </Text>
       </Box>
 
-      <Flex align={{ base: "stretch", md: "end" }} direction={{ base: "column", md: "row" }} gap={4} mb={4}>
+      <Flex
+        align={{ base: "stretch", md: "end" }}
+        direction={{ base: "column", md: "row" }}
+        gap={4}
+        mb={4}
+      >
         <FormControl maxW={{ base: "100%", md: "360px" }}>
           <FormLabel fontSize="sm" fontWeight="semibold">
             Exercise
@@ -167,6 +172,7 @@ const ExerciseTrendSection: React.FC<ExerciseTrendSectionProps> = ({
           gap={2}
           role="group"
           wrap="wrap"
+          w={{ base: "100%", md: "auto" }}
         >
           {METRIC_OPTIONS.map((option) => {
             const isSelected = option.value === metric;
@@ -179,6 +185,7 @@ const ExerciseTrendSection: React.FC<ExerciseTrendSectionProps> = ({
                 onClick={() => setMetric(option.value)}
                 size="sm"
                 variant={isSelected ? "solid" : "outline"}
+                minW={{ base: "calc(50% - 4px)", sm: "auto" }}
               >
                 {option.label}
               </Button>
@@ -207,7 +214,7 @@ const ExerciseTrendSection: React.FC<ExerciseTrendSectionProps> = ({
             <Thead bg="gray.50">
               <Tr>
                 <Th whiteSpace="nowrap">Date</Th>
-                <Th>Exercise</Th>
+                <Th minW="180px">Exercise</Th>
                 <Th>Metric</Th>
                 <Th isNumeric>Value</Th>
               </Tr>
@@ -216,7 +223,9 @@ const ExerciseTrendSection: React.FC<ExerciseTrendSectionProps> = ({
               {recentRows.map((point, index) => (
                 <Tr key={`${point.x}:${point.y}:${index}`}>
                   <Td whiteSpace="nowrap">{point.x}</Td>
-                  <Td>{point.label ?? selectedGroup?.groupName ?? "-"}</Td>
+                  <Td maxW="260px" whiteSpace="normal" wordBreak="break-word">
+                    {point.label ?? selectedGroup?.groupName ?? "-"}
+                  </Td>
                   <Td>{METRIC_LABELS[metric]}</Td>
                   <Td isNumeric>{formatNumber(point.y)}</Td>
                 </Tr>

--- a/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
+++ b/frontend/features/analytics/components/MuscleGroupSummarySection.tsx
@@ -79,6 +79,7 @@ const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
         mb={4}
         role="group"
         wrap="wrap"
+        w={{ base: "100%", md: "auto" }}
       >
         {METRIC_OPTIONS.map((option) => {
           const isSelected = option.value === metric;
@@ -91,6 +92,7 @@ const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
               onClick={() => setMetric(option.value)}
               size="sm"
               variant={isSelected ? "solid" : "outline"}
+              minW={{ base: "calc(50% - 4px)", sm: "auto" }}
             >
               {option.label}
             </Button>
@@ -104,7 +106,7 @@ const MuscleGroupSummarySection: React.FC<MuscleGroupSummarySectionProps> = ({
 
       {visibleRows.length === 0 ? (
         <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
-          <Text color="gray.500">No data yet</Text>
+          <Text color="gray.500">No muscle group rows in this range.</Text>
         </Box>
       ) : (
         <TableContainer border="1px solid" borderColor="gray.200" borderRadius="6px">

--- a/frontend/features/analytics/components/MuscleGroupVolumeChart.tsx
+++ b/frontend/features/analytics/components/MuscleGroupVolumeChart.tsx
@@ -171,7 +171,7 @@ const MuscleGroupVolumeChart: React.FC<MuscleGroupVolumeChartProps> = ({
   if (visibleSeries.length === 0 || chartRows.length === 0) {
     return (
       <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
-        <Text color="gray.500">No muscle group volume data yet</Text>
+        <Text color="gray.500">No muscle group volume data in this range.</Text>
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
- Polished Analytics chart UX without adding new features
- Made chart empty states more specific and range-aware
- Improved Exercise trend chart description for canonical metadata behavior
- Added raw exercise name display to Exercise trend tooltip
- Improved Exercise fallback table handling for long exercise names
- Adjusted metric button groups for better mobile wrapping
- Updated verification docs

## Verification
- `npm test` passed
  - 15 test suites passed
  - 161 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` returned HTTP 200 on the dev server
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No DB changes
- No backend API changes
- No backend service changes
- No RPE/RIR input
- No AI summary
- No multiple-exercise comparison