### PR TITLE
Add set intensity validation helper

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -41,6 +41,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared BIG3 trend aggregation tests are included in `npm test` and CI.
 - Shared weekly muscle group volume aggregation tests are included in `npm test` and CI.
 - Shared training graph data transformation tests are included in `npm test` and CI.
+- Shared set intensity validation tests for RPE/RIR/failure are included in `npm test` and CI.
+- RPE/RIR/failure validation helpers exist but are not wired into the note input UI yet.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
@@ -60,7 +62,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add RPE/RIR input, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
+- Add frontend Set type extension, optional advanced set input UI, backend defensive validation, analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/setIntensityValidation.spec.ts
+++ b/shared/utils/__tests__/setIntensityValidation.spec.ts
@@ -1,0 +1,144 @@
+import {
+  normalizeFailure,
+  normalizeRir,
+  normalizeRpe,
+  normalizeSetIntensity,
+} from "../setIntensityValidation";
+
+describe("setIntensityValidation", () => {
+  describe("normalizeRpe", () => {
+    it("normalizes empty values to null", () => {
+      expect(normalizeRpe(null)).toBeNull();
+      expect(normalizeRpe(undefined)).toBeNull();
+      expect(normalizeRpe("")).toBeNull();
+      expect(normalizeRpe("  ")).toBeNull();
+    });
+
+    it("keeps valid numeric values", () => {
+      expect(normalizeRpe(1)).toBe(1);
+      expect(normalizeRpe(7.5)).toBe(7.5);
+      expect(normalizeRpe(10)).toBe(10);
+      expect(normalizeRpe("8.5")).toBe(8.5);
+    });
+
+    it("normalizes out-of-range and invalid values to null", () => {
+      expect(normalizeRpe(0)).toBeNull();
+      expect(normalizeRpe(10.5)).toBeNull();
+      expect(normalizeRpe(-1)).toBeNull();
+      expect(normalizeRpe(Number.NaN)).toBeNull();
+      expect(normalizeRpe(Number.POSITIVE_INFINITY)).toBeNull();
+      expect(normalizeRpe(Number.NEGATIVE_INFINITY)).toBeNull();
+      expect(normalizeRpe("abc")).toBeNull();
+    });
+  });
+
+  describe("normalizeRir", () => {
+    it("normalizes empty values to null", () => {
+      expect(normalizeRir(null)).toBeNull();
+      expect(normalizeRir(undefined)).toBeNull();
+      expect(normalizeRir("")).toBeNull();
+      expect(normalizeRir("  ")).toBeNull();
+    });
+
+    it("keeps valid numeric values", () => {
+      expect(normalizeRir(0)).toBe(0);
+      expect(normalizeRir(2)).toBe(2);
+      expect(normalizeRir(10)).toBe(10);
+      expect(normalizeRir("1")).toBe(1);
+    });
+
+    it("normalizes out-of-range and invalid values to null", () => {
+      expect(normalizeRir(-1)).toBeNull();
+      expect(normalizeRir(10.5)).toBeNull();
+      expect(normalizeRir(Number.NaN)).toBeNull();
+      expect(normalizeRir(Number.POSITIVE_INFINITY)).toBeNull();
+      expect(normalizeRir(Number.NEGATIVE_INFINITY)).toBeNull();
+      expect(normalizeRir("abc")).toBeNull();
+    });
+  });
+
+  describe("normalizeFailure", () => {
+    it("keeps boolean values", () => {
+      expect(normalizeFailure(true)).toBe(true);
+      expect(normalizeFailure(false)).toBe(false);
+    });
+
+    it("parses supported string values", () => {
+      expect(normalizeFailure("true")).toBe(true);
+      expect(normalizeFailure("false")).toBe(false);
+    });
+
+    it("normalizes empty and invalid values to null", () => {
+      expect(normalizeFailure(null)).toBeNull();
+      expect(normalizeFailure(undefined)).toBeNull();
+      expect(normalizeFailure("")).toBeNull();
+      expect(normalizeFailure("  ")).toBeNull();
+      expect(normalizeFailure("yes")).toBeNull();
+      expect(normalizeFailure(1)).toBeNull();
+    });
+  });
+
+  describe("normalizeSetIntensity", () => {
+    it("normalizes all valid fields", () => {
+      expect(
+        normalizeSetIntensity({
+          rpe: "8.5",
+          rir: 1,
+          failure: "false",
+        })
+      ).toEqual({
+        rpe: 8.5,
+        rir: 1,
+        failure: false,
+      });
+    });
+
+    it("returns null fields for missing values", () => {
+      expect(normalizeSetIntensity({})).toEqual({
+        rpe: null,
+        rir: null,
+        failure: null,
+      });
+    });
+
+    it("handles null, undefined, and non-object input", () => {
+      const expected = {
+        rpe: null,
+        rir: null,
+        failure: null,
+      };
+
+      expect(normalizeSetIntensity(null)).toEqual(expected);
+      expect(normalizeSetIntensity(undefined)).toEqual(expected);
+      expect(normalizeSetIntensity("not-an-object")).toEqual(expected);
+      expect(normalizeSetIntensity(123)).toEqual(expected);
+    });
+
+    it("normalizes invalid values to null", () => {
+      expect(
+        normalizeSetIntensity({
+          rpe: 11,
+          rir: -1,
+          failure: "no",
+        })
+      ).toEqual({
+        rpe: null,
+        rir: null,
+        failure: null,
+      });
+    });
+
+    it("does not mutate input", () => {
+      const input = {
+        rpe: "9",
+        rir: "0",
+        failure: true,
+      };
+      const original = { ...input };
+
+      normalizeSetIntensity(input);
+
+      expect(input).toEqual(original);
+    });
+  });
+});

--- a/shared/utils/setIntensityValidation.ts
+++ b/shared/utils/setIntensityValidation.ts
@@ -1,0 +1,100 @@
+export type SetIntensityInput = {
+  rpe?: string | number | null;
+  rir?: string | number | null;
+  failure?: boolean | string | null;
+};
+
+export type NormalizedSetIntensity = {
+  rpe: number | null;
+  rir: number | null;
+  failure: boolean | null;
+};
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return null;
+  }
+
+  if (typeof value !== "number" && typeof value !== "string") {
+    return null;
+  }
+
+  const parsed = typeof value === "number" ? value : Number(value.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const normalizeBoundedNumber = (
+  value: unknown,
+  min: number,
+  max: number
+): number | null => {
+  const parsed = toFiniteNumber(value);
+  if (parsed === null || parsed < min || parsed > max) {
+    return null;
+  }
+
+  return parsed;
+};
+
+export const normalizeRpe = (value: unknown): number | null => (
+  normalizeBoundedNumber(value, 1, 10)
+);
+
+export const normalizeRir = (value: unknown): number | null => (
+  normalizeBoundedNumber(value, 0, 10)
+);
+
+export const normalizeFailure = (value: unknown): boolean | null => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (normalized === "") {
+    return null;
+  }
+
+  if (normalized === "true") {
+    return true;
+  }
+
+  if (normalized === "false") {
+    return false;
+  }
+
+  return null;
+};
+
+const isRecord = (input: unknown): input is Record<string, unknown> => (
+  typeof input === "object" && input !== null
+);
+
+export const normalizeSetIntensity = (
+  input: unknown
+): NormalizedSetIntensity => {
+  if (!isRecord(input)) {
+    return {
+      rpe: null,
+      rir: null,
+      failure: null,
+    };
+  }
+
+  return {
+    rpe: normalizeRpe(input.rpe),
+    rir: normalizeRir(input.rir),
+    failure: normalizeFailure(input.failure),
+  };
+};


### PR DESCRIPTION
## Summary
- Added shared pure validation helpers for set-level RPE/RIR/failure
- Added `normalizeRpe`, `normalizeRir`, `normalizeFailure`, and `normalizeSetIntensity`
- Added tests for valid values, invalid values, boundaries, empty values, non-object input, and mutation safety
- Updated verification docs

## Verification
- `npm test` passed
  - 16 test suites passed
  - 175 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No UI changes
- No API changes
- No DB changes
- No backend service changes
- Helper is not wired into note input UI yet