### PR TITLE
Extend frontend set intensity types

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -43,6 +43,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training graph data transformation tests are included in `npm test` and CI.
 - Shared set intensity validation tests for RPE/RIR/failure are included in `npm test` and CI.
 - RPE/RIR/failure validation helpers exist but are not wired into the note input UI yet.
+- Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
+- The optional intensity fields are not wired into the note input UI yet; save behavior and backend API remain unchanged.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
@@ -62,7 +64,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add frontend Set type extension, optional advanced set input UI, backend defensive validation, analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
+- Add optional advanced set input UI, backend defensive validation, analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/notes/components/table-body.tsx
+++ b/frontend/features/notes/components/table-body.tsx
@@ -1,17 +1,7 @@
 // frontend/features/notes/components/table-body.tsx
 import React from "react";
 import { Tr, Td, Input, Button, useBreakpointValue } from "@chakra-ui/react";
-
-interface Set {
-  weight: string;
-  reps: string;
-  rest: string;
-}
-
-interface Exercise {
-  exercise: string;
-  sets: Set[];
-}
+import type { Exercise, SetTextField } from "../../../types/types";
 
 interface TableBodyProps {
   exercises: Exercise[];
@@ -23,7 +13,7 @@ interface TableBodyProps {
     e: React.ChangeEvent<HTMLInputElement>,
     exerciseIndex: number,
     setIndex: number,
-    field: keyof Set
+    field: SetTextField
   ) => void;
   onAddSet: (exerciseIndex: number) => void;
 }

--- a/frontend/features/notes/hooks/useNoteHandlers.ts
+++ b/frontend/features/notes/hooks/useNoteHandlers.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { NoteData, Set, Exercise } from "../../../types/types";
+import type { NoteData, SetTextField, Exercise } from "../../../types/types";
 import { getToken } from "../../../../shared/utils/tokenUtils";
 import { saveNoteAPI } from "../api";
 
@@ -38,7 +38,7 @@ const useNoteHandlers = (
       e: React.ChangeEvent<HTMLInputElement>,
       exerciseIndex: number,
       setIndex: number,
-      field: keyof Set
+      field: SetTextField
     ) => {
       if (!noteData) return;
       const newExercises = [...noteData.exercises];

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -4,7 +4,12 @@ export interface Set {
   weight: string;
   reps: string;
   rest: string;
+  rpe?: string | number | null;
+  rir?: string | number | null;
+  failure?: boolean | null;
 }
+
+export type SetTextField = "weight" | "reps" | "rest";
 
 export interface Exercise {
   exercise: string;


### PR DESCRIPTION
## Summary
- Extended frontend note set types with optional `rpe`, `rir`, and `failure` fields
- Restricted current text input handler fields to `weight`, `reps`, and `rest`
- Reused central note `Exercise` / `SetTextField` types in the note table body
- Updated verification docs

## Verification
- `npm test` passed
  - 16 test suites passed
  - 175 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No UI behavior changes
- No save payload changes intended
- No API changes
- No DB changes
- No backend service changes
- `setIntensityValidation` is not wired into the note input UI yet