### PR TITLE
Add optional set effort input UI

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -42,9 +42,10 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared weekly muscle group volume aggregation tests are included in `npm test` and CI.
 - Shared training graph data transformation tests are included in `npm test` and CI.
 - Shared set intensity validation tests for RPE/RIR/failure are included in `npm test` and CI.
-- RPE/RIR/failure validation helpers exist but are not wired into the note input UI yet.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
-- The optional intensity fields are not wired into the note input UI yet; save behavior and backend API remain unchanged.
+- Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
+- Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
+- Backend defensive validation and analytics effort display are still future tasks.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
@@ -64,7 +65,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add optional advanced set input UI, backend defensive validation, analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
+- Add backend defensive validation, analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/notes/components/note-page.tsx
+++ b/frontend/features/notes/components/note-page.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import {
   Box,
+  Checkbox,
   Text,
   Spinner,
   Center,
@@ -22,6 +23,7 @@ import {
   MenuList,
   MenuItem,
   Flex,
+  Select,
 } from "@chakra-ui/react";
 import {
   ChevronDownIcon,
@@ -42,6 +44,15 @@ import useNoteHandlers from "../hooks/useNoteHandlers";
 import useTagHandlers from "../hooks/useTagHandlers";
 import { useTagColor } from "../contexts/TagColorContext";
 
+const RPE_OPTIONS = Array.from({ length: 19 }, (_, index) => (
+  Number((1 + index * 0.5).toFixed(1))
+));
+const RIR_OPTIONS = Array.from({ length: 11 }, (_, index) => index);
+
+const getEffortRowKey = (exerciseIndex: number, setIndex: number) => (
+  `${exerciseIndex}-${setIndex}`
+);
+
 const NotePage: React.FC = () => {
   const router = useRouter();
   const { date } = router.query;
@@ -52,6 +63,9 @@ const NotePage: React.FC = () => {
   const [allTags, setAllTags] = useState<string[]>([]);
   const [isTagPopoverOpen, setIsTagPopoverOpen] = useState(false);
   const [folded, setFolded] = useState<boolean[]>([]);
+  const [expandedEffortRows, setExpandedEffortRows] = useState<
+    Record<string, boolean>
+  >({});
   const [showPrevious, setShowPrevious] = useState(false);
   const previousPopupRef = useRef<HTMLDivElement | null>(null);
   const [previousNote, setPreviousNote] = useState<NoteData | null>(null);
@@ -127,6 +141,7 @@ const NotePage: React.FC = () => {
 
   const {
     handleInputChange,
+    handleSetIntensityChange,
     handleExerciseChange,
     handleExerciseNoteChange,
     handleDateChange,
@@ -190,6 +205,14 @@ const NotePage: React.FC = () => {
       newState[exIndex] = !newState[exIndex];
       return newState;
     });
+  };
+
+  const toggleEffortRow = (exerciseIndex: number, setIndex: number) => {
+    const key = getEffortRowKey(exerciseIndex, setIndex);
+    setExpandedEffortRows((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
   };
 
   if (!noteData) {
@@ -417,59 +440,166 @@ const NotePage: React.FC = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  {exercise.sets.map((set, sIndex) => (
-                    <tr key={sIndex}>
-                      <td style={tdStyle}>{sIndex + 1}</td>
-                      <td style={tdStyle}>
-                        <input
-                          style={inputStyle}
-                          value={set.weight}
-                          onChange={(ev) =>
-                            handleInputChange(ev, eIndex, sIndex, "weight")
-                          }
-                        />
-                      </td>
-                      <td style={tdStyle}>
-                        <input
-                          style={inputStyle}
-                          value={set.reps}
-                          onChange={(ev) =>
-                            handleInputChange(ev, eIndex, sIndex, "reps")
-                          }
-                        />
-                      </td>
-                      <td style={tdStyle}>
-                        <input
-                          style={inputStyle}
-                          value={set.rest}
-                          onChange={(ev) =>
-                            handleInputChange(ev, eIndex, sIndex, "rest")
-                          }
-                        />
-                      </td>
-                      <td style={tdStyle}>
-                        <Menu isLazy={false}>
-                          <MenuButton
-                            as={Button}
-                            variant="ghost"
-                            size="xs"
-                            px={2}
-                            _hover={{ bg: "gray.100" }}
-                          >
-                            ...
-                          </MenuButton>
-                          <MenuList>
-                            <MenuItem onClick={() => handleDuplicateRow(eIndex, sIndex)}>
-                              Duplicate
-                            </MenuItem>
-                            <MenuItem onClick={() => handleDeleteRow(eIndex, sIndex)}>
-                              Delete
-                            </MenuItem>
-                          </MenuList>
-                        </Menu>
-                      </td>
-                    </tr>
-                  ))}
+                  {exercise.sets.map((set, sIndex) => {
+                    const effortRowKey = getEffortRowKey(eIndex, sIndex);
+                    const isEffortExpanded = Boolean(expandedEffortRows[effortRowKey]);
+
+                    return (
+                      <React.Fragment key={sIndex}>
+                        <tr>
+                          <td style={tdStyle}>{sIndex + 1}</td>
+                          <td style={tdStyle}>
+                            <input
+                              style={inputStyle}
+                              value={set.weight}
+                              onChange={(ev) =>
+                                handleInputChange(ev, eIndex, sIndex, "weight")
+                              }
+                            />
+                          </td>
+                          <td style={tdStyle}>
+                            <input
+                              style={inputStyle}
+                              value={set.reps}
+                              onChange={(ev) =>
+                                handleInputChange(ev, eIndex, sIndex, "reps")
+                              }
+                            />
+                          </td>
+                          <td style={tdStyle}>
+                            <input
+                              style={inputStyle}
+                              value={set.rest}
+                              onChange={(ev) =>
+                                handleInputChange(ev, eIndex, sIndex, "rest")
+                              }
+                            />
+                          </td>
+                          <td style={tdStyle}>
+                            <Flex justify="center" align="center" gap={1} flexWrap="wrap">
+                              <Button
+                                size="xs"
+                                variant={isEffortExpanded ? "solid" : "outline"}
+                                colorScheme={isEffortExpanded ? "teal" : undefined}
+                                aria-expanded={isEffortExpanded}
+                                aria-controls={`effort-${effortRowKey}`}
+                                onClick={() => toggleEffortRow(eIndex, sIndex)}
+                              >
+                                Effort
+                              </Button>
+                              <Menu isLazy={false}>
+                                <MenuButton
+                                  as={Button}
+                                  variant="ghost"
+                                  size="xs"
+                                  px={2}
+                                  _hover={{ bg: "gray.100" }}
+                                >
+                                  ...
+                                </MenuButton>
+                                <MenuList>
+                                  <MenuItem onClick={() => handleDuplicateRow(eIndex, sIndex)}>
+                                    Duplicate
+                                  </MenuItem>
+                                  <MenuItem onClick={() => handleDeleteRow(eIndex, sIndex)}>
+                                    Delete
+                                  </MenuItem>
+                                </MenuList>
+                              </Menu>
+                            </Flex>
+                          </td>
+                        </tr>
+                        {isEffortExpanded && (
+                          <tr id={`effort-${effortRowKey}`}>
+                            <td colSpan={5} style={effortTdStyle}>
+                              <Flex
+                                align="center"
+                                justify="center"
+                                gap={3}
+                                flexWrap="wrap"
+                              >
+                                <Text fontSize="sm" fontWeight="semibold">
+                                  Effort
+                                </Text>
+                                <Box minW={{ base: "84px", md: "96px" }}>
+                                  <Text fontSize="xs" mb={1}>
+                                    RPE
+                                  </Text>
+                                  <Select
+                                    aria-label={`RPE for set ${sIndex + 1}`}
+                                    size="sm"
+                                    value={
+                                      set.rpe === null || set.rpe === undefined
+                                        ? ""
+                                        : String(set.rpe)
+                                    }
+                                    onChange={(ev) =>
+                                      handleSetIntensityChange(
+                                        eIndex,
+                                        sIndex,
+                                        "rpe",
+                                        ev.target.value
+                                      )
+                                    }
+                                  >
+                                    <option value="">-</option>
+                                    {RPE_OPTIONS.map((value) => (
+                                      <option key={value} value={value}>
+                                        {value}
+                                      </option>
+                                    ))}
+                                  </Select>
+                                </Box>
+                                <Box minW={{ base: "84px", md: "96px" }}>
+                                  <Text fontSize="xs" mb={1}>
+                                    RIR
+                                  </Text>
+                                  <Select
+                                    aria-label={`RIR for set ${sIndex + 1}`}
+                                    size="sm"
+                                    value={
+                                      set.rir === null || set.rir === undefined
+                                        ? ""
+                                        : String(set.rir)
+                                    }
+                                    onChange={(ev) =>
+                                      handleSetIntensityChange(
+                                        eIndex,
+                                        sIndex,
+                                        "rir",
+                                        ev.target.value
+                                      )
+                                    }
+                                  >
+                                    <option value="">-</option>
+                                    {RIR_OPTIONS.map((value) => (
+                                      <option key={value} value={value}>
+                                        {value}
+                                      </option>
+                                    ))}
+                                  </Select>
+                                </Box>
+                                <Checkbox
+                                  size="sm"
+                                  isChecked={set.failure === true}
+                                  onChange={(ev) =>
+                                    handleSetIntensityChange(
+                                      eIndex,
+                                      sIndex,
+                                      "failure",
+                                      ev.target.checked ? true : null
+                                    )
+                                  }
+                                >
+                                  Failure
+                                </Checkbox>
+                              </Flex>
+                            </td>
+                          </tr>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
                 </tbody>
                 <tfoot>
                   <tr>
@@ -515,6 +645,11 @@ const tdStyle: React.CSSProperties = {
   border: "1px solid #000",
   padding: "8px",
   textAlign: "center",
+};
+
+const effortTdStyle: React.CSSProperties = {
+  ...tdStyle,
+  background: "#f7fafc",
 };
 
 const inputStyle: React.CSSProperties = {

--- a/frontend/features/notes/hooks/useNoteHandlers.ts
+++ b/frontend/features/notes/hooks/useNoteHandlers.ts
@@ -2,8 +2,19 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import type { NoteData, SetTextField, Exercise } from "../../../types/types";
+import type {
+  NoteData,
+  SetIntensityField,
+  SetIntensityInputValue,
+  SetTextField,
+  Exercise,
+} from "../../../types/types";
 import { getToken } from "../../../../shared/utils/tokenUtils";
+import {
+  normalizeFailure,
+  normalizeRir,
+  normalizeRpe,
+} from "../../../../shared/utils/setIntensityValidation";
 import { saveNoteAPI } from "../api";
 
 /**
@@ -43,6 +54,43 @@ const useNoteHandlers = (
       if (!noteData) return;
       const newExercises = [...noteData.exercises];
       newExercises[exerciseIndex].sets[setIndex][field] = e.target.value;
+      const newData = { ...noteData, exercises: newExercises };
+      setNoteData(newData);
+      saveNote(newData);
+    },
+    [noteData, saveNote, setNoteData]
+  );
+
+  const handleSetIntensityChange = useCallback(
+    (
+      exerciseIndex: number,
+      setIndex: number,
+      field: SetIntensityField,
+      value: SetIntensityInputValue
+    ) => {
+      if (!noteData) return;
+
+      const newExercises = [...noteData.exercises];
+      const exercise = newExercises[exerciseIndex];
+      const currentSet = exercise?.sets[setIndex];
+      if (!exercise || !currentSet) return;
+
+      const nextSet = { ...currentSet };
+      if (field === "rpe") {
+        nextSet.rpe = normalizeRpe(value);
+      } else if (field === "rir") {
+        nextSet.rir = normalizeRir(value);
+      } else {
+        nextSet.failure = normalizeFailure(value);
+      }
+
+      newExercises[exerciseIndex] = {
+        ...exercise,
+        sets: exercise.sets.map((set, index) => (
+          index === setIndex ? nextSet : set
+        )),
+      };
+
       const newData = { ...noteData, exercises: newExercises };
       setNoteData(newData);
       saveNote(newData);
@@ -161,6 +209,7 @@ const useNoteHandlers = (
 
   return {
     handleInputChange,
+    handleSetIntensityChange,
     handleExerciseChange,
     handleExerciseNoteChange,
     handleDateChange,

--- a/frontend/types/types.ts
+++ b/frontend/types/types.ts
@@ -10,6 +10,8 @@ export interface Set {
 }
 
 export type SetTextField = "weight" | "reps" | "rest";
+export type SetIntensityField = "rpe" | "rir" | "failure";
+export type SetIntensityInputValue = string | number | boolean | null;
 
 export interface Exercise {
   exercise: string;


### PR DESCRIPTION
## Summary
- Added optional set-level Effort UI for RPE/RIR/failure
- Kept the existing weight/reps/rest row as the primary note input flow
- Added an Effort toggle per set row
- Captures RPE, RIR, and Failure as optional set fields
- Uses existing set intensity validation helpers
- Updated verification docs

## Verification
- `npm test` passed
  - 16 test suites passed
  - 175 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/note/new` returned HTTP 200 on the dev server
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No DB changes
- No backend API changes
- No backend service changes
- Backend defensive validation remains a future task
- Analytics effort display remains a future task