### PR TITLE
Add backend note exercises validation

### DIFF
--- a/backend/services/__tests__/noteService.spec.js
+++ b/backend/services/__tests__/noteService.spec.js
@@ -11,7 +11,7 @@ jest.mock("../../utils/supabaseClient", () => ({
   from,
 }));
 
-const { getNotes, createTag, getNotesByTags } = require("../noteService");
+const { getNotes, saveNote, createTag, getNotesByTags } = require("../noteService");
 
 const createResponse = () => {
   const res = {
@@ -81,6 +81,108 @@ describe("noteService", () => {
       expect(eqUserId).toHaveBeenCalledWith("userid", "user-123");
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({ notes });
+    });
+  });
+
+  describe("saveNote", () => {
+    it("passes normalized exercises to Supabase upsert", async () => {
+      const upsert = jest.fn().mockResolvedValue({ error: null });
+      from.mockReturnValue({ upsert });
+      verifyToken.mockResolvedValue({ id: "user-123" });
+      const req = {
+        params: { date: "2024-06-01" },
+        headers: { authorization: "Bearer valid-token" },
+        body: {
+          note: "Bench day",
+          tags: ["push"],
+          exercises: JSON.stringify([
+            {
+              exercise: "Bench Press",
+              sets: [
+                {
+                  weight: "100",
+                  reps: "5",
+                  rest: "120",
+                  rpe: "8.5",
+                  rir: "1",
+                  failure: "false",
+                },
+                {
+                  weight: "90",
+                  reps: "8",
+                  rest: "90",
+                  rpe: "invalid",
+                  rir: 11,
+                  failure: "unknown",
+                },
+              ],
+            },
+          ]),
+        },
+      };
+      const res = createResponse();
+
+      await saveNote(req, res);
+
+      expect(from).toHaveBeenCalledWith("notes");
+      expect(upsert).toHaveBeenCalledWith(
+        [
+          {
+            date: "2024-06-01",
+            note: "Bench day",
+            exercises: expect.any(String),
+            tags: ["push"],
+            userid: "user-123",
+          },
+        ],
+        { onConflict: ["date", "userid"] }
+      );
+
+      const savedNote = upsert.mock.calls[0][0][0];
+      expect(JSON.parse(savedNote.exercises)).toEqual([
+        {
+          exercise: "Bench Press",
+          sets: [
+            {
+              weight: "100",
+              reps: "5",
+              rest: "120",
+              rpe: 8.5,
+              rir: 1,
+              failure: false,
+            },
+            {
+              weight: "90",
+              reps: "8",
+              rest: "90",
+            },
+          ],
+        },
+      ]);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: "Note saved successfully!" });
+    });
+
+    it("normalizes invalid exercises without crashing saveNote", async () => {
+      const upsert = jest.fn().mockResolvedValue({ error: null });
+      from.mockReturnValue({ upsert });
+      verifyToken.mockResolvedValue({ id: "user-123" });
+      const req = {
+        params: { date: "2024-06-01" },
+        headers: { authorization: "Bearer valid-token" },
+        body: {
+          note: "Invalid exercise payload",
+          tags: [],
+          exercises: "{not-json",
+        },
+      };
+      const res = createResponse();
+
+      await saveNote(req, res);
+
+      expect(upsert.mock.calls[0][0][0].exercises).toBe("[]");
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ message: "Note saved successfully!" });
     });
   });
 

--- a/backend/services/noteService.js
+++ b/backend/services/noteService.js
@@ -2,6 +2,9 @@
 
 const supabase = require("../utils/supabaseClient");
 const { verifyToken } = require("../utils/authUtils");
+const {
+  normalizeExercisesPayloadForSave,
+} = require("../utils/noteExercisesValidation");
 
 /**
  * GET /api/notes/:date
@@ -48,6 +51,7 @@ async function saveNote(req, res) {
       return res.status(401).json({ error: "Invalid token" });
     }
     const { note, exercises, tags } = req.body;
+    const normalizedExercises = normalizeExercisesPayloadForSave(exercises);
     const { error } = await supabase
       .from("notes")
       .upsert(
@@ -55,7 +59,7 @@ async function saveNote(req, res) {
           {
             date,
             note,
-            exercises,
+            exercises: normalizedExercises,
             tags,
             userid: user.id,
           },

--- a/backend/utils/__tests__/noteExercisesValidation.spec.js
+++ b/backend/utils/__tests__/noteExercisesValidation.spec.js
@@ -1,0 +1,199 @@
+/** @jest-environment node */
+
+const {
+  normalizeExercisesPayloadForSave,
+} = require("../noteExercisesValidation");
+
+const parseOutput = (input) => JSON.parse(normalizeExercisesPayloadForSave(input));
+
+describe("noteExercisesValidation", () => {
+  it("normalizes null and undefined input to an empty JSON array", () => {
+    expect(normalizeExercisesPayloadForSave(null)).toBe("[]");
+    expect(normalizeExercisesPayloadForSave(undefined)).toBe("[]");
+  });
+
+  it("normalizes array input to a JSON string", () => {
+    const output = normalizeExercisesPayloadForSave([
+      {
+        exercise: "Bench Press",
+        sets: [{ weight: "100", reps: "5", rest: "120" }],
+      },
+    ]);
+
+    expect(typeof output).toBe("string");
+    expect(JSON.parse(output)).toEqual([
+      {
+        exercise: "Bench Press",
+        sets: [{ weight: "100", reps: "5", rest: "120" }],
+      },
+    ]);
+  });
+
+  it("normalizes valid JSON string input to a sanitized JSON string", () => {
+    const input = JSON.stringify([
+      {
+        exercise: "Squat",
+        note: "top set",
+        sets: [{ weight: "140", reps: "3", rest: "180", rpe: "8.5" }],
+      },
+    ]);
+
+    expect(parseOutput(input)).toEqual([
+      {
+        exercise: "Squat",
+        note: "top set",
+        sets: [{ weight: "140", reps: "3", rest: "180", rpe: 8.5 }],
+      },
+    ]);
+  });
+
+  it("normalizes invalid JSON string input to an empty JSON array", () => {
+    expect(normalizeExercisesPayloadForSave("{not-json")).toBe("[]");
+  });
+
+  it("preserves exercise objects and normalizes missing or invalid sets", () => {
+    expect(
+      parseOutput([
+        {
+          exercise: "Deadlift",
+          note: null,
+          sets: [{ weight: "180", reps: "1", rest: "240" }],
+        },
+        {
+          exercise: "Bench Press",
+        },
+        {
+          exercise: "Pull Up",
+          sets: "not-an-array",
+        },
+      ])
+    ).toEqual([
+      {
+        exercise: "Deadlift",
+        note: null,
+        sets: [{ weight: "180", reps: "1", rest: "240" }],
+      },
+      {
+        exercise: "Bench Press",
+        sets: [],
+      },
+      {
+        exercise: "Pull Up",
+        sets: [],
+      },
+    ]);
+  });
+
+  it("preserves weight, reps, and rest values without coercing them", () => {
+    expect(
+      parseOutput([
+        {
+          exercise: "Row",
+          sets: [{ weight: 80, reps: "8", rest: null }],
+        },
+      ])[0].sets[0]
+    ).toEqual({
+      weight: 80,
+      reps: "8",
+      rest: null,
+    });
+  });
+
+  it("keeps valid rpe and rir values as numbers", () => {
+    expect(
+      parseOutput([
+        {
+          exercise: "Bench Press",
+          sets: [
+            { weight: "100", reps: "5", rpe: "8.5", rir: "1" },
+            { weight: "102.5", reps: "3", rpe: 9, rir: 0 },
+          ],
+        },
+      ])[0].sets
+    ).toEqual([
+      { weight: "100", reps: "5", rpe: 8.5, rir: 1 },
+      { weight: "102.5", reps: "3", rpe: 9, rir: 0 },
+    ]);
+  });
+
+  it("removes invalid or null rpe and rir values", () => {
+    expect(
+      parseOutput([
+        {
+          exercise: "Bench Press",
+          sets: [
+            { weight: "100", reps: "5", rpe: 0, rir: -1 },
+            { weight: "100", reps: "5", rpe: 10.5, rir: 10.5 },
+            { weight: "100", reps: "5", rpe: null, rir: "" },
+            { weight: "100", reps: "5", rpe: Number.NaN, rir: Number.POSITIVE_INFINITY },
+          ],
+        },
+      ])[0].sets
+    ).toEqual([
+      { weight: "100", reps: "5" },
+      { weight: "100", reps: "5" },
+      { weight: "100", reps: "5" },
+      { weight: "100", reps: "5" },
+    ]);
+  });
+
+  it("normalizes supported failure values", () => {
+    expect(
+      parseOutput([
+        {
+          exercise: "Squat",
+          sets: [
+            { weight: "120", reps: "5", failure: true },
+            { weight: "120", reps: "5", failure: false },
+            { weight: "120", reps: "5", failure: "true" },
+            { weight: "120", reps: "5", failure: "false" },
+          ],
+        },
+      ])[0].sets
+    ).toEqual([
+      { weight: "120", reps: "5", failure: true },
+      { weight: "120", reps: "5", failure: false },
+      { weight: "120", reps: "5", failure: true },
+      { weight: "120", reps: "5", failure: false },
+    ]);
+  });
+
+  it("removes invalid or null failure values", () => {
+    expect(
+      parseOutput([
+        {
+          exercise: "Squat",
+          sets: [
+            { weight: "120", reps: "5", failure: null },
+            { weight: "120", reps: "5", failure: "" },
+            { weight: "120", reps: "5", failure: "yes" },
+          ],
+        },
+      ])[0].sets
+    ).toEqual([
+      { weight: "120", reps: "5" },
+      { weight: "120", reps: "5" },
+      { weight: "120", reps: "5" },
+    ]);
+  });
+
+  it("does not mutate input objects or arrays", () => {
+    const input = [
+      {
+        exercise: "Bench Press",
+        sets: [{ weight: "100", reps: "5", rpe: "8" }],
+      },
+    ];
+    const original = JSON.parse(JSON.stringify(input));
+
+    normalizeExercisesPayloadForSave(input);
+
+    expect(input).toEqual(original);
+  });
+
+  it("always returns parseable JSON string output", () => {
+    expect(() => JSON.parse(normalizeExercisesPayloadForSave({}))).not.toThrow();
+    expect(() => JSON.parse(normalizeExercisesPayloadForSave([]))).not.toThrow();
+    expect(() => JSON.parse(normalizeExercisesPayloadForSave("[{}]"))).not.toThrow();
+  });
+});

--- a/backend/utils/noteExercisesValidation.js
+++ b/backend/utils/noteExercisesValidation.js
@@ -1,0 +1,155 @@
+const EMPTY_EXERCISES = "[]";
+
+const hasOwn = (input, key) => Object.prototype.hasOwnProperty.call(input, key);
+
+const isRecord = (input) => (
+  typeof input === "object" && input !== null && !Array.isArray(input)
+);
+
+const toFiniteNumber = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "string" && value.trim() === "") {
+    return null;
+  }
+
+  if (typeof value !== "number" && typeof value !== "string") {
+    return null;
+  }
+
+  const parsed = typeof value === "number" ? value : Number(value.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const normalizeBoundedNumber = (value, min, max) => {
+  const parsed = toFiniteNumber(value);
+  if (parsed === null || parsed < min || parsed > max) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const normalizeRpe = (value) => normalizeBoundedNumber(value, 1, 10);
+
+const normalizeRir = (value) => normalizeBoundedNumber(value, 0, 10);
+
+const normalizeFailure = (value) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (normalized === "") {
+    return null;
+  }
+
+  if (normalized === "true") {
+    return true;
+  }
+
+  if (normalized === "false") {
+    return false;
+  }
+
+  return null;
+};
+
+const sanitizeSet = (set) => {
+  if (!isRecord(set)) {
+    return {};
+  }
+
+  const sanitized = { ...set };
+  const rpe = normalizeRpe(set.rpe);
+  const rir = normalizeRir(set.rir);
+  const failure = normalizeFailure(set.failure);
+
+  delete sanitized.rpe;
+  delete sanitized.rir;
+  delete sanitized.failure;
+
+  if (rpe !== null) {
+    sanitized.rpe = rpe;
+  }
+
+  if (rir !== null) {
+    sanitized.rir = rir;
+  }
+
+  if (failure !== null) {
+    sanitized.failure = failure;
+  }
+
+  return sanitized;
+};
+
+const sanitizeExercise = (exercise) => {
+  if (!isRecord(exercise)) {
+    return {
+      exercise: "",
+      sets: [],
+    };
+  }
+
+  const sanitized = { ...exercise };
+  const exerciseName = hasOwn(exercise, "exercise") ? exercise.exercise : "";
+
+  sanitized.exercise = exerciseName === null || exerciseName === undefined
+    ? ""
+    : String(exerciseName);
+
+  if (hasOwn(exercise, "note")) {
+    if (exercise.note === undefined) {
+      delete sanitized.note;
+    } else if (exercise.note !== null && typeof exercise.note !== "string") {
+      sanitized.note = String(exercise.note);
+    }
+  }
+
+  sanitized.sets = Array.isArray(exercise.sets)
+    ? exercise.sets.map(sanitizeSet)
+    : [];
+
+  return sanitized;
+};
+
+const parseExercisesInput = (exercises) => {
+  if (Array.isArray(exercises)) {
+    return exercises;
+  }
+
+  if (typeof exercises !== "string") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(exercises);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const normalizeExercisesPayloadForSave = (exercises) => {
+  const parsedExercises = parseExercisesInput(exercises);
+  if (parsedExercises.length === 0) {
+    return EMPTY_EXERCISES;
+  }
+
+  return JSON.stringify(parsedExercises.map(sanitizeExercise));
+};
+
+module.exports = {
+  normalizeExercisesPayloadForSave,
+};

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -45,7 +45,7 @@ GitHub Actions runs the same baseline on push and pull request:
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
-- Backend defensive validation and analytics effort display are still future tasks.
+- Analytics effort display is still a future task.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
@@ -55,7 +55,9 @@ GitHub Actions runs the same baseline on push and pull request:
 - Frontend analytics canonical exercise grouping helper tests are included in `npm test` and CI.
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
+- Backend note exercises validation tests are included in `npm test` and CI.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
+- Backend `saveNote` defensively normalizes nested exercise intensity fields before persistence.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
 - `--passWithNoTests` was removed after adding shared tests to the Jest baseline.
 - Test output no longer includes the old `calendarUtils` debug log or the `ts-jest` `esModuleInterop` warning.
@@ -65,7 +67,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add backend defensive validation, analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
+- Add analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.


### PR DESCRIPTION
## Summary
- Added backend defensive normalization for nested note exercises payloads
- Added `normalizeExercisesPayloadForSave`
- Normalizes RPE/RIR/failure before persistence
- Removes invalid/null intensity fields from saved payloads
- Wires normalization into `saveNote`
- Added helper and note service tests
- Updated verification docs

## Verification
- `npm test` passed
  - 17 test suites passed
  - 189 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No frontend UI changes
- No DB changes
- No backend route/API contract changes
- Analytics effort display remains a future task