### PR TITLE
Add analytics effort display

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -42,14 +42,16 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared weekly muscle group volume aggregation tests are included in `npm test` and CI.
 - Shared training graph data transformation tests are included in `npm test` and CI.
 - Shared set intensity validation tests for RPE/RIR/failure are included in `npm test` and CI.
+- Shared effort analytics summary tests are included in `npm test` and CI.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
-- Analytics effort display is still a future task.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
 - Analytics includes an exercise trend selector using existing normalized set metrics and canonical exercise groups when metadata matches.
+- Analytics displays set-level effort summary for RPE/RIR/failure when logged.
+- Missing effort values are treated as unknown, not zero.
 - Analytics chart empty states are range-aware, and exact-value fallback tables remain available for BIG3, muscle groups, and exercise trends.
 - Unmatched exercise trends remain raw-name groups; exercise chart tooltips and fallback tables show raw exercise names.
 - Frontend analytics canonical exercise grouping helper tests are included in `npm test` and CI.
@@ -67,7 +69,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add analytics effort display, AI weekly summaries, and DB-backed/custom exercise catalog exploration.
+- Add AI weekly summaries, DB-backed/custom exercise catalog exploration, and expanded effort trend charts if needed.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/EffortSummarySection.tsx
+++ b/frontend/features/analytics/components/EffortSummarySection.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatHelpText,
+  StatLabel,
+  StatNumber,
+  Text,
+} from "@chakra-ui/react";
+import type { EffortAnalyticsSummary } from "../../../../shared/utils/effortAnalytics";
+
+type EffortSummarySectionProps = {
+  summary: EffortAnalyticsSummary;
+};
+
+const formatNumber = (value: number | null): string => {
+  if (value === null) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+const EffortSummarySection: React.FC<EffortSummarySectionProps> = ({
+  summary,
+}) => {
+  const hasEffortData = summary.effortLoggedSetCount > 0;
+
+  return (
+    <Box as="section" aria-labelledby="effort-summary-heading">
+      <Box mb={4}>
+        <Heading id="effort-summary-heading" as="h2" size="md">
+          Effort
+        </Heading>
+        <Text mt={1} fontSize="sm" color="gray.600">
+          Set-level RPE, RIR, and failure summary for the selected range.
+        </Text>
+      </Box>
+
+      {!hasEffortData ? (
+        <Box border="1px solid" borderColor="gray.200" borderRadius="6px" p={6}>
+          <Text color="gray.500">No effort data in this range.</Text>
+        </Box>
+      ) : (
+        <SimpleGrid columns={{ base: 1, sm: 2, lg: 4 }} spacing={4}>
+          <Box
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="6px"
+            bg="white"
+            p={4}
+          >
+            <Stat>
+              <StatLabel>Effort Coverage</StatLabel>
+              <StatNumber>
+                {summary.effortLoggedSetCount} / {summary.totalSetCount}
+              </StatNumber>
+              <StatHelpText>sets with RPE, RIR, or failure logged</StatHelpText>
+            </Stat>
+          </Box>
+
+          <Box
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="6px"
+            bg="white"
+            p={4}
+          >
+            <Stat>
+              <StatLabel>Average RPE</StatLabel>
+              <StatNumber>{formatNumber(summary.averageRpe)}</StatNumber>
+              <StatHelpText>{summary.rpeCount} logged sets</StatHelpText>
+            </Stat>
+          </Box>
+
+          <Box
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="6px"
+            bg="white"
+            p={4}
+          >
+            <Stat>
+              <StatLabel>Average RIR</StatLabel>
+              <StatNumber>{formatNumber(summary.averageRir)}</StatNumber>
+              <StatHelpText>{summary.rirCount} logged sets</StatHelpText>
+            </Stat>
+          </Box>
+
+          <Box
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="6px"
+            bg="white"
+            p={4}
+          >
+            <Stat>
+              <StatLabel>Failure Sets</StatLabel>
+              <StatNumber>{summary.failureCount}</StatNumber>
+              <StatHelpText>sets marked as failure</StatHelpText>
+            </Stat>
+          </Box>
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+};
+
+export default EffortSummarySection;

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -30,6 +30,7 @@ import {
   type WeeklyMuscleGroupVolumeRow,
 } from "../../../../shared/utils/muscleGroupVolume";
 import { normalizeWorkoutSets } from "../../../../shared/utils/normalizeWorkoutSets";
+import { summarizeSetEffort } from "../../../../shared/utils/effortAnalytics";
 import {
   toBig3EstimatedOneRepMaxSeries,
 } from "../../../../shared/utils/trainingGraphData";
@@ -42,6 +43,7 @@ import AnalyticsRangeFilter, {
   type AnalyticsRange,
 } from "../components/AnalyticsRangeFilter";
 import Big3SummarySection from "../components/Big3SummarySection";
+import EffortSummarySection from "../components/EffortSummarySection";
 import ExerciseTrendSection from "../components/ExerciseTrendSection";
 import MuscleGroupSummarySection from "../components/MuscleGroupSummarySection";
 
@@ -101,6 +103,10 @@ const AnalyticsPage: React.FC = () => {
     () => toBig3EstimatedOneRepMaxSeries(big3Summaries),
     [big3Summaries]
   );
+  const effortSummary = useMemo(
+    () => summarizeSetEffort(setsWithMetrics),
+    [setsWithMetrics]
+  );
 
   useEffect(() => {
     if (!getToken()) {
@@ -144,8 +150,10 @@ const AnalyticsPage: React.FC = () => {
   }, [dateRange.end, dateRange.start, reloadKey, router]);
 
   const hasExerciseData = setsWithMetrics.some((set) => set.exerciseName.trim() !== "");
+  const hasEffortData = effortSummary.effortLoggedSetCount > 0;
   const hasAnalyticsData = big3Series.some((series) => series.points.length > 0)
     || muscleRows.length > 0
+    || hasEffortData
     || hasExerciseData;
 
   return (
@@ -229,6 +237,9 @@ const AnalyticsPage: React.FC = () => {
                 <MuscleGroupSummarySection rows={muscleRows} />
               </TabPanel>
               <TabPanel px={0} py={6}>
+                <Box mb={8}>
+                  <EffortSummarySection summary={effortSummary} />
+                </Box>
                 <ExerciseTrendSection sets={setsWithMetrics} />
               </TabPanel>
             </TabPanels>

--- a/shared/utils/__tests__/effortAnalytics.spec.ts
+++ b/shared/utils/__tests__/effortAnalytics.spec.ts
@@ -1,0 +1,104 @@
+import { summarizeSetEffort } from "../effortAnalytics";
+
+describe("effortAnalytics", () => {
+  describe("summarizeSetEffort", () => {
+    it("returns an empty summary for empty input", () => {
+      expect(summarizeSetEffort([])).toEqual({
+        totalSetCount: 0,
+        effortLoggedSetCount: 0,
+        rpeCount: 0,
+        averageRpe: null,
+        rirCount: 0,
+        averageRir: null,
+        failureCount: 0,
+      });
+    });
+
+    it("counts logged effort fields and averages rpe and rir", () => {
+      expect(
+        summarizeSetEffort([
+          { rpe: 8, rir: 2, failure: null },
+          { rpe: 9, rir: 1, failure: true },
+          { rpe: null, rir: null, failure: null },
+        ])
+      ).toEqual({
+        totalSetCount: 3,
+        effortLoggedSetCount: 2,
+        rpeCount: 2,
+        averageRpe: 8.5,
+        rirCount: 2,
+        averageRir: 1.5,
+        failureCount: 1,
+      });
+    });
+
+    it("treats missing effort values as unknown rather than zero", () => {
+      expect(
+        summarizeSetEffort([
+          { rpe: null, rir: null, failure: null },
+          {},
+        ])
+      ).toEqual({
+        totalSetCount: 2,
+        effortLoggedSetCount: 0,
+        rpeCount: 0,
+        averageRpe: null,
+        rirCount: 0,
+        averageRir: null,
+        failureCount: 0,
+      });
+    });
+
+    it("counts failure false as logged effort but not as a failure set", () => {
+      expect(
+        summarizeSetEffort([
+          { rpe: null, rir: null, failure: false },
+          { rpe: null, rir: null, failure: true },
+        ])
+      ).toEqual({
+        totalSetCount: 2,
+        effortLoggedSetCount: 2,
+        rpeCount: 0,
+        averageRpe: null,
+        rirCount: 0,
+        averageRir: null,
+        failureCount: 1,
+      });
+    });
+
+    it("ignores non-finite rpe and rir values", () => {
+      expect(
+        summarizeSetEffort([
+          { rpe: Number.NaN, rir: Number.POSITIVE_INFINITY, failure: null },
+          { rpe: 7.25, rir: 2.5, failure: null },
+        ])
+      ).toEqual({
+        totalSetCount: 2,
+        effortLoggedSetCount: 1,
+        rpeCount: 1,
+        averageRpe: 7.25,
+        rirCount: 1,
+        averageRir: 2.5,
+        failureCount: 0,
+      });
+    });
+
+    it("rounds averages to two decimals", () => {
+      expect(
+        summarizeSetEffort([
+          { rpe: 7, rir: 1, failure: null },
+          { rpe: 8, rir: 2, failure: null },
+          { rpe: 10, rir: 4, failure: null },
+        ])
+      ).toEqual({
+        totalSetCount: 3,
+        effortLoggedSetCount: 3,
+        rpeCount: 3,
+        averageRpe: 8.33,
+        rirCount: 3,
+        averageRir: 2.33,
+        failureCount: 0,
+      });
+    });
+  });
+});

--- a/shared/utils/effortAnalytics.ts
+++ b/shared/utils/effortAnalytics.ts
@@ -1,0 +1,94 @@
+export type EffortSetInput = {
+  rpe?: number | null;
+  rir?: number | null;
+  failure?: boolean | null;
+};
+
+export type EffortAnalyticsSummary = {
+  totalSetCount: number;
+  effortLoggedSetCount: number;
+  rpeCount: number;
+  averageRpe: number | null;
+  rirCount: number;
+  averageRir: number | null;
+  failureCount: number;
+};
+
+const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
+
+const isFiniteNumber = (value: number | null | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+const isLoggedFailure = (value: boolean | null | undefined): value is boolean => (
+  typeof value === "boolean"
+);
+
+export const summarizeSetEffort = (
+  sets: EffortSetInput[]
+): EffortAnalyticsSummary => {
+  if (!Array.isArray(sets) || sets.length === 0) {
+    return {
+      totalSetCount: 0,
+      effortLoggedSetCount: 0,
+      rpeCount: 0,
+      averageRpe: null,
+      rirCount: 0,
+      averageRir: null,
+      failureCount: 0,
+    };
+  }
+
+  const totals = sets.reduce(
+    (summary, set) => {
+      const rpe = isFiniteNumber(set.rpe) ? set.rpe : null;
+      const rir = isFiniteNumber(set.rir) ? set.rir : null;
+      const hasFailure = isLoggedFailure(set.failure);
+
+      summary.totalSetCount += 1;
+
+      if (rpe !== null || rir !== null || hasFailure) {
+        summary.effortLoggedSetCount += 1;
+      }
+
+      if (rpe !== null) {
+        summary.rpeTotal += rpe;
+        summary.rpeCount += 1;
+      }
+
+      if (rir !== null) {
+        summary.rirTotal += rir;
+        summary.rirCount += 1;
+      }
+
+      if (set.failure === true) {
+        summary.failureCount += 1;
+      }
+
+      return summary;
+    },
+    {
+      totalSetCount: 0,
+      effortLoggedSetCount: 0,
+      rpeTotal: 0,
+      rpeCount: 0,
+      rirTotal: 0,
+      rirCount: 0,
+      failureCount: 0,
+    }
+  );
+
+  return {
+    totalSetCount: totals.totalSetCount,
+    effortLoggedSetCount: totals.effortLoggedSetCount,
+    rpeCount: totals.rpeCount,
+    averageRpe: totals.rpeCount > 0
+      ? roundToTwoDecimals(totals.rpeTotal / totals.rpeCount)
+      : null,
+    rirCount: totals.rirCount,
+    averageRir: totals.rirCount > 0
+      ? roundToTwoDecimals(totals.rirTotal / totals.rirCount)
+      : null,
+    failureCount: totals.failureCount,
+  };
+};


### PR DESCRIPTION
## Summary
- Added shared effort analytics summary helper
- Added effort summary display to the Exercises tab
- Displays effort coverage, average RPE, average RIR, and failure set count
- Treats missing effort values as unknown, not zero
- Added tests for effort summary aggregation
- Updated verification docs

## Verification
- `npm test` passed
  - 18 test suites passed
  - 195 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` returned HTTP 200 on the dev server
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No DB changes
- No backend/API changes
- No note input UI changes
- AI weekly summaries remain a future task
- Expanded effort trend charts remain optional future work