### PR TITLE
Add weekly summary input builder

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -43,6 +43,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared training graph data transformation tests are included in `npm test` and CI.
 - Shared set intensity validation tests for RPE/RIR/failure are included in `npm test` and CI.
 - Shared effort analytics summary tests are included in `npm test` and CI.
+- Shared weekly summary input builder tests are included in `npm test` and CI.
+- Weekly summary input builder prepares deterministic aggregate data for future AI/rule-based summaries without calling an AI API.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
@@ -69,7 +71,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add AI weekly summary input builder and rule-based summary preview, DB-backed/custom exercise catalog exploration, and expanded effort trend charts if needed.
+- Add rule-based weekly summary preview, prompt builder docs/tests, DB-backed/custom exercise catalog exploration, and expanded effort trend charts if needed.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/weeklySummaryInput.spec.ts
+++ b/shared/utils/__tests__/weeklySummaryInput.spec.ts
@@ -1,0 +1,318 @@
+import type {
+  Big3LiftType,
+  Big3TrendPoint,
+  Big3TrendSummary,
+} from "../big3Trend";
+import type { EffortAnalyticsSummary } from "../effortAnalytics";
+import type { WeeklyMuscleGroupVolumeRow } from "../muscleGroupVolume";
+import { buildWeeklySummaryInput } from "../weeklySummaryInput";
+
+const makePoint = (
+  liftType: Big3LiftType,
+  estimatedOneRepMax: number | null,
+  date = "2026-06-01"
+): Big3TrendPoint => ({
+  date,
+  liftType,
+  exerciseName: liftType === "bench" ? "Bench Press" : liftType,
+  setIndex: 0,
+  weight: 100,
+  reps: 5,
+  estimatedOneRepMax,
+  volumeLoad: 500,
+});
+
+const makeSummary = (
+  liftType: Big3LiftType,
+  estimatedValues: Array<number | null>
+): Big3TrendSummary => {
+  const points = estimatedValues.map((value, index) => (
+    makePoint(liftType, value, `2026-06-${String(index + 1).padStart(2, "0")}`)
+  ));
+  const validPoints = points.filter((point) => (
+    typeof point.estimatedOneRepMax === "number" &&
+    Number.isFinite(point.estimatedOneRepMax) &&
+    point.estimatedOneRepMax > 0
+  ));
+
+  return {
+    liftType,
+    points,
+    latestTopSet: validPoints.at(-1) ?? null,
+    maxEstimatedOneRepMax: validPoints.reduce<Big3TrendPoint | null>((best, point) => {
+      if (!best || (point.estimatedOneRepMax ?? 0) > (best.estimatedOneRepMax ?? 0)) {
+        return point;
+      }
+      return best;
+    }, null),
+  };
+};
+
+const effortSummary: EffortAnalyticsSummary = {
+  totalSetCount: 10,
+  effortLoggedSetCount: 5,
+  rpeCount: 4,
+  averageRpe: 8.25,
+  rirCount: 3,
+  averageRir: 1.5,
+  failureCount: 2,
+};
+
+const buildInput = (overrides: Partial<Parameters<typeof buildWeeklySummaryInput>[0]> = {}) => (
+  buildWeeklySummaryInput({
+    rangeStart: "2026-06-01",
+    rangeEnd: "2026-06-07",
+    totalNotes: 3,
+    normalizedSets: [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}],
+    big3Summaries: [
+      makeSummary("squat", [150, 155]),
+      makeSummary("bench", [100, 102.5]),
+      makeSummary("deadlift", [180]),
+    ],
+    muscleRows: [
+      {
+        weekStart: "2026-06-01",
+        muscle: "chest",
+        totalSets: 4,
+        totalVolumeLoad: 1200,
+        exercises: ["Bench Press"],
+      },
+      {
+        weekStart: "2026-06-01",
+        muscle: "back",
+        totalSets: 6,
+        totalVolumeLoad: 1800,
+        exercises: ["Barbell Row"],
+      },
+      {
+        weekStart: "2026-06-08",
+        muscle: "chest",
+        totalSets: 3,
+        totalVolumeLoad: 900,
+        exercises: ["Dumbbell Press"],
+      },
+    ],
+    effortSummary,
+    ...overrides,
+  })
+);
+
+describe("weeklySummaryInput", () => {
+  describe("buildWeeklySummaryInput", () => {
+    it("builds deterministic aggregate summary input from full data", () => {
+      expect(buildInput()).toEqual({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        totalNotes: 3,
+        totalSets: 10,
+        big3: [
+          {
+            lift: "squat",
+            latestEstimatedOneRepMax: 155,
+            maxEstimatedOneRepMax: 155,
+            trendPointCount: 2,
+          },
+          {
+            lift: "bench",
+            latestEstimatedOneRepMax: 102.5,
+            maxEstimatedOneRepMax: 102.5,
+            trendPointCount: 2,
+          },
+          {
+            lift: "deadlift",
+            latestEstimatedOneRepMax: 180,
+            maxEstimatedOneRepMax: 180,
+            trendPointCount: 1,
+          },
+        ],
+        muscleGroups: [
+          {
+            muscle: "chest",
+            totalSets: 7,
+            totalVolumeLoad: 2100,
+          },
+          {
+            muscle: "back",
+            totalSets: 6,
+            totalVolumeLoad: 1800,
+          },
+        ],
+        effort: effortSummary,
+        dataQualityNotes: [],
+      });
+    });
+
+    it("adds a data quality note when no notes are present", () => {
+      expect(buildInput({ totalNotes: 0 }).dataQualityNotes).toContain(
+        "No workout notes found in this range."
+      );
+    });
+
+    it("adds a data quality note when no normalized sets are present", () => {
+      expect(buildInput({ normalizedSets: [] }).dataQualityNotes).toContain(
+        "No normalized sets found in this range."
+      );
+    });
+
+    it("adds a data quality note when no BIG3 trend points are present", () => {
+      expect(
+        buildInput({
+          big3Summaries: [
+            makeSummary("squat", []),
+            makeSummary("bench", []),
+            makeSummary("deadlift", []),
+          ],
+        }).dataQualityNotes
+      ).toContain("No BIG3 trend data found in this range.");
+    });
+
+    it("adds a data quality note when no muscle group rows are present", () => {
+      expect(buildInput({ muscleRows: [] }).dataQualityNotes).toContain(
+        "No muscle group volume data found in this range."
+      );
+    });
+
+    it("adds a data quality note when no effort data is logged", () => {
+      expect(
+        buildInput({
+          effortSummary: {
+            totalSetCount: 10,
+            effortLoggedSetCount: 0,
+            rpeCount: 0,
+            averageRpe: null,
+            rirCount: 0,
+            averageRir: null,
+            failureCount: 0,
+          },
+        }).dataQualityNotes
+      ).toContain("No effort data logged in this range.");
+    });
+
+    it("adds a data quality note when effort data is sparse", () => {
+      expect(
+        buildInput({
+          effortSummary: {
+            ...effortSummary,
+            totalSetCount: 10,
+            effortLoggedSetCount: 2,
+          },
+        }).dataQualityNotes
+      ).toContain("Effort data is sparse in this range.");
+    });
+
+    it("does not surface invalid numeric values as finite numbers", () => {
+      const input = buildInput({
+        totalNotes: Number.NaN,
+        big3Summaries: [
+          {
+            liftType: "bench",
+            points: [
+              makePoint("bench", Number.NaN),
+              makePoint("bench", Number.POSITIVE_INFINITY),
+              makePoint("bench", -100),
+            ],
+            latestTopSet: makePoint("bench", Number.NaN),
+            maxEstimatedOneRepMax: makePoint("bench", Number.POSITIVE_INFINITY),
+          },
+        ],
+        muscleRows: [
+          {
+            weekStart: "2026-06-01",
+            muscle: "chest",
+            totalSets: Number.NaN,
+            totalVolumeLoad: Number.POSITIVE_INFINITY,
+            exercises: [],
+          },
+        ],
+        effortSummary: {
+          totalSetCount: Number.NaN,
+          effortLoggedSetCount: Number.POSITIVE_INFINITY,
+          rpeCount: -1,
+          averageRpe: Number.NaN,
+          rirCount: 1,
+          averageRir: Number.POSITIVE_INFINITY,
+          failureCount: -1,
+        },
+      });
+
+      expect(input.totalNotes).toBe(0);
+      expect(input.big3).toEqual([
+        {
+          lift: "bench",
+          latestEstimatedOneRepMax: null,
+          maxEstimatedOneRepMax: null,
+          trendPointCount: 0,
+        },
+      ]);
+      expect(input.muscleGroups).toEqual([]);
+      expect(input.effort).toEqual({
+        totalSetCount: 0,
+        effortLoggedSetCount: 0,
+        rpeCount: 0,
+        averageRpe: null,
+        rirCount: 1,
+        averageRir: null,
+        failureCount: 0,
+      });
+    });
+
+    it("does not mutate input data", () => {
+      const args = {
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        totalNotes: 1,
+        normalizedSets: [{ id: "set-1" }],
+        big3Summaries: [makeSummary("bench", [100])],
+        muscleRows: [
+          {
+            weekStart: "2026-06-01",
+            muscle: "chest",
+            totalSets: 3,
+            totalVolumeLoad: 900,
+            exercises: ["Bench Press"],
+          },
+        ],
+        effortSummary,
+      };
+      const original = JSON.parse(JSON.stringify(args));
+
+      buildWeeklySummaryInput(args);
+
+      expect(args).toEqual(original);
+    });
+
+    it("sorts muscle groups by total sets desc and muscle asc", () => {
+      const input = buildInput({
+        muscleRows: [
+          {
+            weekStart: "2026-06-01",
+            muscle: "chest",
+            totalSets: 5,
+            totalVolumeLoad: 1000,
+            exercises: [],
+          },
+          {
+            weekStart: "2026-06-01",
+            muscle: "back",
+            totalSets: 5,
+            totalVolumeLoad: 1100,
+            exercises: [],
+          },
+          {
+            weekStart: "2026-06-01",
+            muscle: "quads",
+            totalSets: 8,
+            totalVolumeLoad: 1500,
+            exercises: [],
+          },
+        ],
+      });
+
+      expect(input.muscleGroups.map((row) => row.muscle)).toEqual([
+        "quads",
+        "back",
+        "chest",
+      ]);
+    });
+  });
+});

--- a/shared/utils/weeklySummaryInput.ts
+++ b/shared/utils/weeklySummaryInput.ts
@@ -1,0 +1,223 @@
+import type { Big3TrendSummary } from "./big3Trend";
+import type { EffortAnalyticsSummary } from "./effortAnalytics";
+import type { WeeklyMuscleGroupVolumeRow } from "./muscleGroupVolume";
+
+export type WeeklySummaryBig3Input = {
+  lift: string;
+  latestEstimatedOneRepMax: number | null;
+  maxEstimatedOneRepMax: number | null;
+  trendPointCount: number;
+};
+
+export type WeeklySummaryMuscleGroupInput = {
+  muscle: string;
+  totalSets: number;
+  totalVolumeLoad: number;
+};
+
+export type WeeklySummaryInput = {
+  rangeStart: string;
+  rangeEnd: string;
+  totalNotes: number;
+  totalSets: number;
+  big3: WeeklySummaryBig3Input[];
+  muscleGroups: WeeklySummaryMuscleGroupInput[];
+  effort: EffortAnalyticsSummary;
+  dataQualityNotes: string[];
+};
+
+export type BuildWeeklySummaryInputArgs = {
+  rangeStart: string;
+  rangeEnd: string;
+  totalNotes: number;
+  normalizedSets: unknown[];
+  big3Summaries: Big3TrendSummary[];
+  muscleRows: WeeklyMuscleGroupVolumeRow[];
+  effortSummary: EffortAnalyticsSummary;
+};
+
+const NO_NOTES_NOTE = "No workout notes found in this range.";
+const NO_SETS_NOTE = "No normalized sets found in this range.";
+const NO_BIG3_NOTE = "No BIG3 trend data found in this range.";
+const NO_MUSCLE_NOTE = "No muscle group volume data found in this range.";
+const NO_EFFORT_NOTE = "No effort data logged in this range.";
+const SPARSE_EFFORT_NOTE = "Effort data is sparse in this range.";
+
+const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
+
+const isFiniteNumber = (value: number | null | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+const isPositiveFiniteNumber = (value: number | null | undefined): value is number => (
+  isFiniteNumber(value) && value > 0
+);
+
+const toFiniteNumberOrNull = (value: number | null | undefined): number | null => (
+  isFiniteNumber(value) ? value : null
+);
+
+const toPositiveFiniteNumberOrNull = (
+  value: number | null | undefined
+): number | null => (
+  isPositiveFiniteNumber(value) ? value : null
+);
+
+const toNonNegativeNumber = (value: number | null | undefined): number => (
+  isFiniteNumber(value) && value >= 0 ? value : 0
+);
+
+const toCount = (value: number | null | undefined): number => (
+  Math.floor(toNonNegativeNumber(value))
+);
+
+const sanitizeEffortSummary = (
+  effortSummary: EffortAnalyticsSummary
+): EffortAnalyticsSummary => ({
+  totalSetCount: toCount(effortSummary.totalSetCount),
+  effortLoggedSetCount: toCount(effortSummary.effortLoggedSetCount),
+  rpeCount: toCount(effortSummary.rpeCount),
+  averageRpe: toFiniteNumberOrNull(effortSummary.averageRpe),
+  rirCount: toCount(effortSummary.rirCount),
+  averageRir: toFiniteNumberOrNull(effortSummary.averageRir),
+  failureCount: toCount(effortSummary.failureCount),
+});
+
+const buildBig3Input = (
+  big3Summaries: Big3TrendSummary[]
+): WeeklySummaryBig3Input[] => {
+  if (!Array.isArray(big3Summaries)) {
+    return [];
+  }
+
+  return big3Summaries.map((summary) => ({
+    lift: summary.liftType,
+    latestEstimatedOneRepMax: toPositiveFiniteNumberOrNull(
+      summary.latestTopSet?.estimatedOneRepMax
+    ),
+    maxEstimatedOneRepMax: toPositiveFiniteNumberOrNull(
+      summary.maxEstimatedOneRepMax?.estimatedOneRepMax
+    ),
+    trendPointCount: Array.isArray(summary.points)
+      ? summary.points.filter((point) => (
+        isPositiveFiniteNumber(point.estimatedOneRepMax)
+      )).length
+      : 0,
+  }));
+};
+
+const buildMuscleGroupInput = (
+  muscleRows: WeeklyMuscleGroupVolumeRow[]
+): WeeklySummaryMuscleGroupInput[] => {
+  if (!Array.isArray(muscleRows) || muscleRows.length === 0) {
+    return [];
+  }
+
+  const groups = new Map<string, WeeklySummaryMuscleGroupInput>();
+
+  muscleRows.forEach((row) => {
+    const muscle = typeof row.muscle === "string" ? row.muscle.trim() : "";
+    if (muscle === "") {
+      return;
+    }
+
+    const current = groups.get(muscle) ?? {
+      muscle,
+      totalSets: 0,
+      totalVolumeLoad: 0,
+    };
+
+    current.totalSets += toNonNegativeNumber(row.totalSets);
+    current.totalVolumeLoad += toNonNegativeNumber(row.totalVolumeLoad);
+
+    groups.set(muscle, current);
+  });
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      muscle: group.muscle,
+      totalSets: roundToTwoDecimals(group.totalSets),
+      totalVolumeLoad: roundToTwoDecimals(group.totalVolumeLoad),
+    }))
+    .filter((group) => group.totalSets > 0 || group.totalVolumeLoad > 0)
+    .sort((a, b) => {
+      const setCompare = b.totalSets - a.totalSets;
+      return setCompare !== 0 ? setCompare : a.muscle.localeCompare(b.muscle);
+    });
+};
+
+const buildDataQualityNotes = ({
+  totalNotes,
+  totalSets,
+  big3,
+  muscleGroups,
+  effort,
+}: {
+  totalNotes: number;
+  totalSets: number;
+  big3: WeeklySummaryBig3Input[];
+  muscleGroups: WeeklySummaryMuscleGroupInput[];
+  effort: EffortAnalyticsSummary;
+}): string[] => {
+  const notes: string[] = [];
+
+  if (totalNotes === 0) {
+    notes.push(NO_NOTES_NOTE);
+  }
+
+  if (totalSets === 0) {
+    notes.push(NO_SETS_NOTE);
+  }
+
+  if (big3.every((summary) => summary.trendPointCount === 0)) {
+    notes.push(NO_BIG3_NOTE);
+  }
+
+  if (muscleGroups.length === 0) {
+    notes.push(NO_MUSCLE_NOTE);
+  }
+
+  if (effort.effortLoggedSetCount === 0) {
+    notes.push(NO_EFFORT_NOTE);
+  } else if (
+    effort.totalSetCount > 0 &&
+    effort.effortLoggedSetCount / effort.totalSetCount < 0.25
+  ) {
+    notes.push(SPARSE_EFFORT_NOTE);
+  }
+
+  return notes;
+};
+
+export const buildWeeklySummaryInput = ({
+  rangeStart,
+  rangeEnd,
+  totalNotes,
+  normalizedSets,
+  big3Summaries,
+  muscleRows,
+  effortSummary,
+}: BuildWeeklySummaryInputArgs): WeeklySummaryInput => {
+  const safeTotalNotes = toCount(totalNotes);
+  const totalSets = Array.isArray(normalizedSets) ? normalizedSets.length : 0;
+  const big3 = buildBig3Input(big3Summaries);
+  const muscleGroups = buildMuscleGroupInput(muscleRows);
+  const effort = sanitizeEffortSummary(effortSummary);
+
+  return {
+    rangeStart,
+    rangeEnd,
+    totalNotes: safeTotalNotes,
+    totalSets,
+    big3,
+    muscleGroups,
+    effort,
+    dataQualityNotes: buildDataQualityNotes({
+      totalNotes: safeTotalNotes,
+      totalSets,
+      big3,
+      muscleGroups,
+      effort,
+    }),
+  };
+};


### PR DESCRIPTION
## Summary
- Added shared weekly summary input builder
- Builds deterministic aggregate input for future rule-based/AI weekly summaries
- Uses existing analytics data without calling an AI API
- Excludes raw note text, API keys, DB writes, and external provider integration
- Adds data quality notes for empty or sparse data
- Added tests for full data, sparse data, invalid values, non-mutation, and deterministic sorting
- Updated verification docs

## Verification
- `npm test` passed
  - 19 test suites passed
  - 205 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No UI changes
- No API changes
- No DB changes
- No backend service changes
- No external AI API integration
- No API keys or env changes
- Raw note text is not included