### PR TITLE
Add rule-based weekly summary preview

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -45,6 +45,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared effort analytics summary tests are included in `npm test` and CI.
 - Shared weekly summary input builder tests are included in `npm test` and CI.
 - Weekly summary input builder prepares deterministic aggregate data for future AI/rule-based summaries without calling an AI API.
+- Shared rule-based weekly summary tests are included in `npm test` and CI.
+- Analytics displays a deterministic rule-based weekly summary preview without calling an AI API.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
@@ -71,7 +73,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add rule-based weekly summary preview, prompt builder docs/tests, DB-backed/custom exercise catalog exploration, and expanded effort trend charts if needed.
+- Add prompt builder docs/tests, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after prompt/backend design.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/WeeklySummaryPreviewSection.tsx
+++ b/frontend/features/analytics/components/WeeklySummaryPreviewSection.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import {
+  Badge,
+  Box,
+  Flex,
+  Heading,
+  List,
+  ListItem,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import type {
+  RuleBasedWeeklySummary,
+} from "../../../../shared/utils/ruleBasedWeeklySummary";
+
+type WeeklySummaryPreviewSectionProps = {
+  summary: RuleBasedWeeklySummary;
+  rangeStart: string;
+  rangeEnd: string;
+};
+
+type SummaryListProps = {
+  title: string;
+  items: string[];
+  emptyText: string;
+};
+
+const SummaryList: React.FC<SummaryListProps> = ({
+  title,
+  items,
+  emptyText,
+}) => (
+  <Box>
+    <Heading as="h3" size="xs" mb={2} color="gray.700">
+      {title}
+    </Heading>
+    {items.length === 0 ? (
+      <Text fontSize="sm" color="gray.500">
+        {emptyText}
+      </Text>
+    ) : (
+      <List spacing={1}>
+        {items.map((item) => (
+          <ListItem key={item} fontSize="sm" color="gray.700">
+            {item}
+          </ListItem>
+        ))}
+      </List>
+    )}
+  </Box>
+);
+
+const WeeklySummaryPreviewSection: React.FC<WeeklySummaryPreviewSectionProps> = ({
+  summary,
+  rangeStart,
+  rangeEnd,
+}) => (
+  <Box
+    as="section"
+    aria-labelledby="weekly-summary-preview-heading"
+    border="1px solid"
+    borderColor="gray.200"
+    borderRadius="6px"
+    bg="white"
+    p={{ base: 4, md: 5 }}
+  >
+    <Stack spacing={4}>
+      <Flex
+        align={{ base: "flex-start", sm: "center" }}
+        justify="space-between"
+        gap={3}
+        direction={{ base: "column", sm: "row" }}
+      >
+        <Box>
+          <Heading id="weekly-summary-preview-heading" as="h2" size="md">
+            Weekly Summary
+          </Heading>
+          <Text mt={1} fontSize="sm" color="gray.600">
+            {rangeStart} to {rangeEnd}
+          </Text>
+        </Box>
+        <Badge colorScheme="gray" alignSelf={{ base: "flex-start", sm: "center" }}>
+          Rule-based preview
+        </Badge>
+      </Flex>
+
+      <Box bg="gray.50" borderRadius="6px" p={4}>
+        <Text fontWeight="semibold" color="gray.800">
+          {summary.headline}
+        </Text>
+        <Text mt={2} fontSize="sm" color="gray.700">
+          {summary.summary}
+        </Text>
+      </Box>
+
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+        <SummaryList
+          title="Highlights"
+          items={summary.highlights}
+          emptyText="No highlights yet."
+        />
+        <SummaryList
+          title="Concerns"
+          items={summary.concerns}
+          emptyText="No concerns from the available data."
+        />
+        <SummaryList
+          title="Next Week Focus"
+          items={summary.nextWeekFocus}
+          emptyText="No focus items yet."
+        />
+        <SummaryList
+          title="Data Quality"
+          items={summary.dataQualityNotes}
+          emptyText="No data quality notes."
+        />
+      </SimpleGrid>
+    </Stack>
+  </Box>
+);
+
+export default WeeklySummaryPreviewSection;

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -30,6 +30,9 @@ import {
   type WeeklyMuscleGroupVolumeRow,
 } from "../../../../shared/utils/muscleGroupVolume";
 import { normalizeWorkoutSets } from "../../../../shared/utils/normalizeWorkoutSets";
+import {
+  buildRuleBasedWeeklySummary,
+} from "../../../../shared/utils/ruleBasedWeeklySummary";
 import { summarizeSetEffort } from "../../../../shared/utils/effortAnalytics";
 import {
   toBig3EstimatedOneRepMaxSeries,
@@ -38,6 +41,7 @@ import {
   addTrainingMetricsToSet,
   type NormalizedWorkoutSetWithMetrics,
 } from "../../../../shared/utils/trainingMetrics";
+import { buildWeeklySummaryInput } from "../../../../shared/utils/weeklySummaryInput";
 import { fetchNotesInRangeAPI } from "../../notes/api";
 import AnalyticsRangeFilter, {
   type AnalyticsRange,
@@ -46,6 +50,7 @@ import Big3SummarySection from "../components/Big3SummarySection";
 import EffortSummarySection from "../components/EffortSummarySection";
 import ExerciseTrendSection from "../components/ExerciseTrendSection";
 import MuscleGroupSummarySection from "../components/MuscleGroupSummarySection";
+import WeeklySummaryPreviewSection from "../components/WeeklySummaryPreviewSection";
 
 type LoadStatus = "loading" | "success" | "error";
 
@@ -106,6 +111,30 @@ const AnalyticsPage: React.FC = () => {
   const effortSummary = useMemo(
     () => summarizeSetEffort(setsWithMetrics),
     [setsWithMetrics]
+  );
+  const weeklySummaryInput = useMemo(
+    () => buildWeeklySummaryInput({
+      rangeStart: dateRange.start,
+      rangeEnd: dateRange.end,
+      totalNotes: noteCount,
+      normalizedSets: setsWithMetrics,
+      big3Summaries,
+      muscleRows,
+      effortSummary,
+    }),
+    [
+      big3Summaries,
+      dateRange.end,
+      dateRange.start,
+      effortSummary,
+      muscleRows,
+      noteCount,
+      setsWithMetrics,
+    ]
+  );
+  const weeklySummary = useMemo(
+    () => buildRuleBasedWeeklySummary(weeklySummaryInput),
+    [weeklySummaryInput]
   );
 
   useEffect(() => {
@@ -207,6 +236,16 @@ const AnalyticsPage: React.FC = () => {
               Retry
             </Button>
           </Alert>
+        )}
+
+        {status === "success" && (
+          <Box mb={6}>
+            <WeeklySummaryPreviewSection
+              summary={weeklySummary}
+              rangeStart={dateRange.start}
+              rangeEnd={dateRange.end}
+            />
+          </Box>
         )}
 
         {status === "success" && !hasAnalyticsData && (

--- a/shared/utils/__tests__/ruleBasedWeeklySummary.spec.ts
+++ b/shared/utils/__tests__/ruleBasedWeeklySummary.spec.ts
@@ -1,0 +1,290 @@
+import {
+  buildRuleBasedWeeklySummary,
+  type RuleBasedWeeklySummary,
+} from "../ruleBasedWeeklySummary";
+import type { WeeklySummaryInput } from "../weeklySummaryInput";
+
+const buildInput = (overrides: Partial<WeeklySummaryInput> = {}): WeeklySummaryInput => ({
+  rangeStart: "2026-06-01",
+  rangeEnd: "2026-06-07",
+  totalNotes: 3,
+  totalSets: 12,
+  big3: [
+    {
+      lift: "squat",
+      latestEstimatedOneRepMax: 152.5,
+      maxEstimatedOneRepMax: 155,
+      trendPointCount: 2,
+    },
+    {
+      lift: "bench",
+      latestEstimatedOneRepMax: 122.5,
+      maxEstimatedOneRepMax: 125,
+      trendPointCount: 3,
+    },
+    {
+      lift: "deadlift",
+      latestEstimatedOneRepMax: 180,
+      maxEstimatedOneRepMax: 180,
+      trendPointCount: 1,
+    },
+  ],
+  muscleGroups: [
+    {
+      muscle: "chest",
+      totalSets: 10,
+      totalVolumeLoad: 2400,
+    },
+    {
+      muscle: "back",
+      totalSets: 8,
+      totalVolumeLoad: 2100,
+    },
+  ],
+  effort: {
+    totalSetCount: 12,
+    effortLoggedSetCount: 8,
+    rpeCount: 6,
+    averageRpe: 8.25,
+    rirCount: 4,
+    averageRir: 1.5,
+    failureCount: 2,
+  },
+  dataQualityNotes: [],
+  ...overrides,
+});
+
+const expectNoUnsafeNumbers = (summary: RuleBasedWeeklySummary) => {
+  const serialized = JSON.stringify(summary);
+
+  expect(serialized).not.toContain("NaN");
+  expect(serialized).not.toContain("Infinity");
+};
+
+describe("ruleBasedWeeklySummary", () => {
+  describe("buildRuleBasedWeeklySummary", () => {
+    it("builds deterministic summary content from full weekly summary input", () => {
+      const summary = buildRuleBasedWeeklySummary(buildInput());
+
+      expect(summary.headline).toBe("Weekly training summary");
+      expect(summary.summary).toContain("3 workout notes produced 12 normalized sets");
+      expect(summary.summary).toContain("Deadlift at 180 estimated 1RM");
+      expect(summary.summary).toContain("effort was logged for 8 / 12 sets");
+      expect(summary.summary).toContain("average RPE 8.25");
+      expect(summary.summary).toContain("average RIR 1.5");
+      expect(summary.highlights).toEqual([
+        "Deadlift max estimated 1RM: 180.",
+        "chest had the highest logged muscle volume: 10 sets, 2,400 volume load.",
+        "Effort coverage: 8 / 12 sets logged RPE, RIR, or failure.",
+      ]);
+      expect(summary.concerns).toEqual([]);
+      expect(summary.nextWeekFocus).toEqual([
+        "Keep logging RPE/RIR for better effort tracking.",
+        "Watch whether top lifts trend up or down next week.",
+        "Review muscle group volume balance across the week.",
+      ]);
+      expect(summary.dataQualityNotes).toEqual([]);
+    });
+
+    it("returns a cautious no-data summary when no sets are available", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          totalNotes: 0,
+          totalSets: 0,
+          big3: [],
+          muscleGroups: [],
+          effort: {
+            totalSetCount: 0,
+            effortLoggedSetCount: 0,
+            rpeCount: 0,
+            averageRpe: null,
+            rirCount: 0,
+            averageRir: null,
+            failureCount: 0,
+          },
+          dataQualityNotes: [
+            "No workout notes found in this range.",
+            "No normalized sets found in this range.",
+            "No BIG3 trend data found in this range.",
+            "No muscle group volume data found in this range.",
+            "No effort data logged in this range.",
+          ],
+        })
+      );
+
+      expect(summary.headline).toBe("No training data in this range");
+      expect(summary.summary).toContain("No normalized training sets were found");
+      expect(summary.highlights).toEqual([]);
+      expect(summary.concerns).toEqual([
+        "No BIG3 trend data was available for this range.",
+        "No muscle group volume data was available for this range.",
+        "No effort data was logged, so intensity trends are unknown.",
+      ]);
+      expect(summary.nextWeekFocus).toEqual([
+        "Log workouts consistently to unlock weekly summaries.",
+      ]);
+    });
+
+    it("surfaces missing BIG3, muscle group, and effort data as concerns", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          big3: [
+            {
+              lift: "bench",
+              latestEstimatedOneRepMax: null,
+              maxEstimatedOneRepMax: null,
+              trendPointCount: 0,
+            },
+          ],
+          muscleGroups: [],
+          effort: {
+            totalSetCount: 12,
+            effortLoggedSetCount: 0,
+            rpeCount: 0,
+            averageRpe: null,
+            rirCount: 0,
+            averageRir: null,
+            failureCount: 0,
+          },
+          dataQualityNotes: [
+            "No BIG3 trend data found in this range.",
+            "No muscle group volume data found in this range.",
+            "No effort data logged in this range.",
+          ],
+        })
+      );
+
+      expect(summary.concerns).toEqual([
+        "No BIG3 trend data was available for this range.",
+        "No muscle group volume data was available for this range.",
+        "No effort data was logged, so intensity trends are unknown.",
+      ]);
+      expect(summary.summary).toContain("effort trends are unknown");
+    });
+
+    it("flags sparse effort data without treating missing values as low effort", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          effort: {
+            totalSetCount: 12,
+            effortLoggedSetCount: 2,
+            rpeCount: 1,
+            averageRpe: 9,
+            rirCount: 1,
+            averageRir: 1,
+            failureCount: 1,
+          },
+          dataQualityNotes: ["Effort data is sparse in this range."],
+        })
+      );
+
+      expect(summary.concerns).toContain(
+        "Effort data is sparse, so intensity trends may be less reliable."
+      );
+      expect(summary.summary).toContain("effort was logged for 2 / 12 sets");
+    });
+
+    it("flags relatively frequent failure sets", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          effort: {
+            totalSetCount: 12,
+            effortLoggedSetCount: 10,
+            rpeCount: 8,
+            averageRpe: 9,
+            rirCount: 5,
+            averageRir: 0.5,
+            failureCount: 4,
+          },
+        })
+      );
+
+      expect(summary.concerns).toContain(
+        "Failure sets were relatively frequent: 4 / 12 sets were marked as failure."
+      );
+    });
+
+    it("does not surface invalid numeric values", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          totalNotes: Number.NaN,
+          totalSets: Number.POSITIVE_INFINITY,
+          big3: [
+            {
+              lift: "bench",
+              latestEstimatedOneRepMax: Number.NaN,
+              maxEstimatedOneRepMax: Number.POSITIVE_INFINITY,
+              trendPointCount: Number.NaN,
+            },
+          ],
+          muscleGroups: [
+            {
+              muscle: "chest",
+              totalSets: Number.POSITIVE_INFINITY,
+              totalVolumeLoad: Number.NaN,
+            },
+          ],
+          effort: {
+            totalSetCount: Number.NaN,
+            effortLoggedSetCount: Number.POSITIVE_INFINITY,
+            rpeCount: Number.NaN,
+            averageRpe: Number.NaN,
+            rirCount: Number.POSITIVE_INFINITY,
+            averageRir: Number.POSITIVE_INFINITY,
+            failureCount: Number.NaN,
+          },
+        })
+      );
+
+      expect(summary.headline).toBe("No training data in this range");
+      expectNoUnsafeNumbers(summary);
+    });
+
+    it("does not mutate input data", () => {
+      const input = buildInput();
+      const original = JSON.parse(JSON.stringify(input));
+
+      buildRuleBasedWeeklySummary(input);
+
+      expect(input).toEqual(original);
+    });
+
+    it("uses deterministic tie-breaks for top BIG3 and muscle highlights", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          big3: [
+            {
+              lift: "deadlift",
+              latestEstimatedOneRepMax: 200,
+              maxEstimatedOneRepMax: 200,
+              trendPointCount: 2,
+            },
+            {
+              lift: "bench",
+              latestEstimatedOneRepMax: 200,
+              maxEstimatedOneRepMax: 200,
+              trendPointCount: 2,
+            },
+          ],
+          muscleGroups: [
+            {
+              muscle: "chest",
+              totalSets: 10,
+              totalVolumeLoad: 2000,
+            },
+            {
+              muscle: "back",
+              totalSets: 10,
+              totalVolumeLoad: 2100,
+            },
+          ],
+        })
+      );
+
+      expect(summary.highlights[0]).toBe("Bench Press max estimated 1RM: 200.");
+      expect(summary.highlights[1]).toBe(
+        "back had the highest logged muscle volume: 10 sets, 2,100 volume load."
+      );
+    });
+  });
+});

--- a/shared/utils/ruleBasedWeeklySummary.ts
+++ b/shared/utils/ruleBasedWeeklySummary.ts
@@ -1,0 +1,305 @@
+import type {
+  EffortAnalyticsSummary,
+} from "./effortAnalytics";
+import type {
+  WeeklySummaryBig3Input,
+  WeeklySummaryInput,
+  WeeklySummaryMuscleGroupInput,
+} from "./weeklySummaryInput";
+
+export type RuleBasedWeeklySummary = {
+  headline: string;
+  summary: string;
+  highlights: string[];
+  concerns: string[];
+  nextWeekFocus: string[];
+  dataQualityNotes: string[];
+};
+
+const NO_BIG3_NOTE = "No BIG3 trend data found in this range.";
+const NO_MUSCLE_NOTE = "No muscle group volume data found in this range.";
+const NO_EFFORT_NOTE = "No effort data logged in this range.";
+const SPARSE_EFFORT_NOTE = "Effort data is sparse in this range.";
+
+const formatNumber = (value: number): string => (
+  new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(value)
+);
+
+const isFiniteNumber = (value: number | null | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+const isPositiveFiniteNumber = (
+  value: number | null | undefined
+): value is number => (
+  isFiniteNumber(value) && value > 0
+);
+
+const toCount = (value: number | null | undefined): number => (
+  isFiniteNumber(value) && value > 0 ? Math.floor(value) : 0
+);
+
+const toFiniteNumberOrNull = (value: number | null | undefined): number | null => (
+  isFiniteNumber(value) ? value : null
+);
+
+const sanitizeEffortSummary = (
+  effort: EffortAnalyticsSummary
+): EffortAnalyticsSummary => ({
+  totalSetCount: toCount(effort.totalSetCount),
+  effortLoggedSetCount: toCount(effort.effortLoggedSetCount),
+  rpeCount: toCount(effort.rpeCount),
+  averageRpe: toFiniteNumberOrNull(effort.averageRpe),
+  rirCount: toCount(effort.rirCount),
+  averageRir: toFiniteNumberOrNull(effort.averageRir),
+  failureCount: toCount(effort.failureCount),
+});
+
+const formatLift = (lift: string): string => {
+  switch (lift) {
+    case "bench":
+      return "Bench Press";
+    case "deadlift":
+      return "Deadlift";
+    case "squat":
+      return "Squat";
+    default:
+      return lift;
+  }
+};
+
+const getDataQualityNotes = (input: WeeklySummaryInput): string[] => (
+  Array.isArray(input.dataQualityNotes)
+    ? input.dataQualityNotes.filter((note) => typeof note === "string")
+    : []
+);
+
+const getTopBig3 = (
+  big3: WeeklySummaryBig3Input[]
+): WeeklySummaryBig3Input | null => {
+  if (!Array.isArray(big3)) {
+    return null;
+  }
+
+  return [...big3]
+    .filter((summary) => isPositiveFiniteNumber(summary.maxEstimatedOneRepMax))
+    .sort((a, b) => {
+      const valueCompare = (b.maxEstimatedOneRepMax ?? 0)
+        - (a.maxEstimatedOneRepMax ?? 0);
+
+      return valueCompare !== 0
+        ? valueCompare
+        : formatLift(a.lift).localeCompare(formatLift(b.lift));
+    })[0] ?? null;
+};
+
+const getTopMuscleGroup = (
+  muscleGroups: WeeklySummaryMuscleGroupInput[]
+): WeeklySummaryMuscleGroupInput | null => {
+  if (!Array.isArray(muscleGroups)) {
+    return null;
+  }
+
+  return [...muscleGroups]
+    .filter((group) => isPositiveFiniteNumber(group.totalSets))
+    .sort((a, b) => {
+      const setCompare = b.totalSets - a.totalSets;
+
+      return setCompare !== 0 ? setCompare : a.muscle.localeCompare(b.muscle);
+    })[0] ?? null;
+};
+
+const buildSummaryText = ({
+  input,
+  totalNotes,
+  totalSets,
+  topBig3,
+}: {
+  input: WeeklySummaryInput;
+  totalNotes: number;
+  totalSets: number;
+  topBig3: WeeklySummaryBig3Input | null;
+}): string => {
+  if (totalSets === 0) {
+    return `No normalized training sets were found from ${input.rangeStart} to ${input.rangeEnd}. Keep logging workouts to unlock weekly trends.`;
+  }
+
+  const parts = [
+    `From ${input.rangeStart} to ${input.rangeEnd}, ${totalNotes} workout notes produced ${totalSets} normalized sets.`,
+  ];
+
+  if (topBig3?.maxEstimatedOneRepMax !== null && topBig3) {
+    parts.push(
+      `The strongest BIG3 signal was ${formatLift(topBig3.lift)} at ${formatNumber(topBig3.maxEstimatedOneRepMax)} estimated 1RM.`
+    );
+  }
+
+  if (input.effort.effortLoggedSetCount > 0) {
+    const effortDetails = [
+      `effort was logged for ${input.effort.effortLoggedSetCount} / ${input.effort.totalSetCount} sets`,
+    ];
+
+    if (isFiniteNumber(input.effort.averageRpe)) {
+      effortDetails.push(`average RPE ${formatNumber(input.effort.averageRpe)}`);
+    }
+
+    if (isFiniteNumber(input.effort.averageRir)) {
+      effortDetails.push(`average RIR ${formatNumber(input.effort.averageRir)}`);
+    }
+
+    effortDetails.push(`${input.effort.failureCount} failure sets`);
+    parts.push(`${effortDetails.join(", ")}.`);
+  } else {
+    parts.push("No RPE, RIR, or failure data was logged, so effort trends are unknown.");
+  }
+
+  return parts.join(" ");
+};
+
+const buildHighlights = ({
+  input,
+  topBig3,
+  topMuscleGroup,
+}: {
+  input: WeeklySummaryInput;
+  topBig3: WeeklySummaryBig3Input | null;
+  topMuscleGroup: WeeklySummaryMuscleGroupInput | null;
+}): string[] => {
+  const highlights: string[] = [];
+
+  if (topBig3?.maxEstimatedOneRepMax !== null && topBig3) {
+    highlights.push(
+      `${formatLift(topBig3.lift)} max estimated 1RM: ${formatNumber(topBig3.maxEstimatedOneRepMax)}.`
+    );
+  }
+
+  if (topMuscleGroup) {
+    const volumeText = isPositiveFiniteNumber(topMuscleGroup.totalVolumeLoad)
+      ? `, ${formatNumber(topMuscleGroup.totalVolumeLoad)} volume load`
+      : "";
+
+    highlights.push(
+      `${topMuscleGroup.muscle} had the highest logged muscle volume: ${formatNumber(topMuscleGroup.totalSets)} sets${volumeText}.`
+    );
+  }
+
+  if (input.effort.effortLoggedSetCount > 0) {
+    highlights.push(
+      `Effort coverage: ${input.effort.effortLoggedSetCount} / ${input.effort.totalSetCount} sets logged RPE, RIR, or failure.`
+    );
+  }
+
+  return highlights;
+};
+
+const buildConcerns = (input: WeeklySummaryInput, dataQualityNotes: string[]): string[] => {
+  const concerns: string[] = [];
+
+  if (dataQualityNotes.includes(NO_BIG3_NOTE)) {
+    concerns.push("No BIG3 trend data was available for this range.");
+  }
+
+  if (dataQualityNotes.includes(NO_MUSCLE_NOTE)) {
+    concerns.push("No muscle group volume data was available for this range.");
+  }
+
+  if (dataQualityNotes.includes(NO_EFFORT_NOTE)) {
+    concerns.push("No effort data was logged, so intensity trends are unknown.");
+  } else if (dataQualityNotes.includes(SPARSE_EFFORT_NOTE)) {
+    concerns.push("Effort data is sparse, so intensity trends may be less reliable.");
+  }
+
+  if (
+    input.effort.totalSetCount > 0 &&
+    input.effort.failureCount >= 3 &&
+    input.effort.failureCount / input.effort.totalSetCount >= 0.25
+  ) {
+    concerns.push(
+      `Failure sets were relatively frequent: ${input.effort.failureCount} / ${input.effort.totalSetCount} sets were marked as failure.`
+    );
+  }
+
+  return concerns;
+};
+
+const buildNextWeekFocus = ({
+  input,
+  totalSets,
+  topBig3,
+  topMuscleGroup,
+}: {
+  input: WeeklySummaryInput;
+  totalSets: number;
+  topBig3: WeeklySummaryBig3Input | null;
+  topMuscleGroup: WeeklySummaryMuscleGroupInput | null;
+}): string[] => {
+  if (totalSets === 0) {
+    return ["Log workouts consistently to unlock weekly summaries."];
+  }
+
+  const focus: string[] = [];
+  const effortCoverage = input.effort.totalSetCount > 0
+    ? input.effort.effortLoggedSetCount / input.effort.totalSetCount
+    : 0;
+
+  if (effortCoverage < 0.75) {
+    focus.push("Keep logging RPE/RIR for better effort tracking.");
+  }
+
+  focus.push(
+    topBig3
+      ? "Watch whether top lifts trend up or down next week."
+      : "Log squat, bench, or deadlift sets if BIG3 tracking matters."
+  );
+
+  focus.push(
+    topMuscleGroup
+      ? "Review muscle group volume balance across the week."
+      : "Review muscle group volume balance as more data is logged."
+  );
+
+  return focus;
+};
+
+export const buildRuleBasedWeeklySummary = (
+  input: WeeklySummaryInput
+): RuleBasedWeeklySummary => {
+  const totalNotes = toCount(input.totalNotes);
+  const totalSets = toCount(input.totalSets);
+  const dataQualityNotes = getDataQualityNotes(input);
+  const safeInput = {
+    ...input,
+    totalNotes,
+    totalSets,
+    effort: sanitizeEffortSummary(input.effort),
+  };
+  const topBig3 = getTopBig3(input.big3);
+  const topMuscleGroup = getTopMuscleGroup(input.muscleGroups);
+
+  return {
+    headline: totalSets === 0
+      ? "No training data in this range"
+      : "Weekly training summary",
+    summary: buildSummaryText({
+      input: safeInput,
+      totalNotes,
+      totalSets,
+      topBig3,
+    }),
+    highlights: buildHighlights({
+      input: safeInput,
+      topBig3,
+      topMuscleGroup,
+    }),
+    concerns: buildConcerns(safeInput, dataQualityNotes),
+    nextWeekFocus: buildNextWeekFocus({
+      input: safeInput,
+      totalSets,
+      topBig3,
+      topMuscleGroup,
+    }),
+    dataQualityNotes,
+  };
+};


### PR DESCRIPTION
## Summary
- Added deterministic rule-based weekly summary helper
- Added weekly summary preview card to `/analytics`
- Uses existing weekly summary input data without calling an AI API
- Displays headline, summary, highlights, concerns, next week focus, and data quality notes
- Clearly labels the card as `Rule-based preview`
- Added tests for full data, sparse data, no-data handling, invalid numbers, non-mutation, and deterministic tie-breaks
- Updated verification docs

## Verification
- `npm test` passed
  - 20 test suites passed
  - 213 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- `/analytics` returned HTTP 200 on the dev server
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No external AI API integration
- No API keys or env changes
- No prompt implementation
- No DB changes
- No backend API or backend service changes
- No note input UI changes