### PR TITLE
Add weekly summary prompt builder

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -47,6 +47,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Weekly summary input builder prepares deterministic aggregate data for future AI/rule-based summaries without calling an AI API.
 - Shared rule-based weekly summary tests are included in `npm test` and CI.
 - Analytics displays a deterministic rule-based weekly summary preview without calling an AI API.
+- Shared weekly summary prompt builder tests are included in `npm test` and CI.
+- Weekly summary prompt builder creates provider-neutral prompt payloads without calling an external AI API.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
@@ -73,7 +75,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add prompt builder helper/tests, backend AI endpoint design, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after prompt/backend design.
+- Add backend AI endpoint design, weekly summary response validation helper, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after backend design and response validation.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/weeklySummaryPromptBuilder.spec.ts
+++ b/shared/utils/__tests__/weeklySummaryPromptBuilder.spec.ts
@@ -1,0 +1,251 @@
+import {
+  buildWeeklySummaryPromptPayload,
+  toWeeklySummaryPromptMessages,
+  type WeeklySummaryPromptInput,
+  type WeeklySummaryPromptPayload,
+} from "../weeklySummaryPromptBuilder";
+import type { WeeklySummaryInput } from "../weeklySummaryInput";
+
+const weeklySummaryInput: WeeklySummaryInput = {
+  rangeStart: "2026-06-01",
+  rangeEnd: "2026-06-07",
+  totalNotes: 3,
+  totalSets: 12,
+  big3: [
+    {
+      lift: "bench",
+      latestEstimatedOneRepMax: 98,
+      maxEstimatedOneRepMax: 100,
+      trendPointCount: 3,
+    },
+  ],
+  muscleGroups: [
+    {
+      muscle: "chest",
+      totalSets: 8,
+      totalVolumeLoad: 2400,
+    },
+  ],
+  effort: {
+    totalSetCount: 12,
+    effortLoggedSetCount: 8,
+    rpeCount: 6,
+    averageRpe: 8.1,
+    rirCount: 4,
+    averageRir: 1.5,
+    failureCount: 2,
+  },
+  dataQualityNotes: ["Effort data is sparse in this range."],
+};
+
+const buildPayload = (
+  overrides: Partial<WeeklySummaryPromptInput> = {}
+): WeeklySummaryPromptPayload => buildWeeklySummaryPromptPayload({
+  weeklySummaryInput,
+  ...overrides,
+});
+
+describe("weeklySummaryPromptBuilder", () => {
+  describe("buildWeeklySummaryPromptPayload", () => {
+    it("builds provider-neutral prompt payload sections from full input", () => {
+      const payload = buildPayload();
+
+      expect(payload).toEqual({
+        system: expect.any(String),
+        task: expect.any(String),
+        constraints: expect.any(Array),
+        dataInterpretationRules: expect.any(Array),
+        outputFormat: expect.any(String),
+        data: weeklySummaryInput,
+      });
+      expect(payload.task).toContain("weekly workout analytics data");
+      expect(payload.constraints.length).toBeGreaterThan(0);
+      expect(payload.dataInterpretationRules.length).toBeGreaterThan(0);
+    });
+
+    it("includes medical, injury, and provided-data-only constraints in the system instruction", () => {
+      const payload = buildPayload();
+
+      expect(payload.system).toContain("workout analytics data");
+      expect(payload.system).toContain("not a medical professional");
+      expect(payload.system).toContain("must not diagnose injuries");
+      expect(payload.system).toContain("Use only the provided data");
+      expect(payload.system).toContain("Do not invent exercises, dates, weights, PRs, pain, injuries, or goals");
+    });
+
+    it("includes required safety constraints", () => {
+      const payload = buildPayload();
+
+      expect(payload.constraints).toEqual(expect.arrayContaining([
+        "Use only the provided aggregate data.",
+        "Missing values are unknown.",
+        "Missing effort values are not low effort.",
+        "Do not give medical advice.",
+        "Do not diagnose injuries.",
+        "Do not prescribe a fixed training program.",
+        "Do not infer user goals.",
+        "Keep the output concise.",
+        "Return JSON-compatible structured output.",
+      ]));
+    });
+
+    it("includes data interpretation rules for effort, sparse data, BIG3, and raw notes", () => {
+      const payload = buildPayload();
+
+      expect(payload.dataInterpretationRules).toEqual(expect.arrayContaining([
+        "failure count means failure === true only.",
+        "Sparse effort coverage lowers confidence.",
+        "No BIG3 data means no strength trend conclusion.",
+        "No muscle group data means no volume balance conclusion.",
+        "No notes or no sets means a cautious summary.",
+        "Raw note text is not provided.",
+      ]));
+    });
+
+    it("includes required JSON output fields", () => {
+      const payload = buildPayload();
+
+      expect(payload.outputFormat).toContain("headline: string");
+      expect(payload.outputFormat).toContain("summary: string");
+      expect(payload.outputFormat).toContain("highlights: string[]");
+      expect(payload.outputFormat).toContain("concerns: string[]");
+      expect(payload.outputFormat).toContain("nextWeekFocus: string[]");
+      expect(payload.outputFormat).toContain("dataQualityNotes: string[]");
+      expect(payload.outputFormat).toContain("Do not include markdown");
+      expect(payload.outputFormat).toContain("Do not invent data");
+    });
+
+    it("keeps weekly summary input as structured data", () => {
+      expect(buildPayload().data).toEqual(weeklySummaryInput);
+    });
+
+    it("does not include raw note text from accidental extra input fields", () => {
+      const inputWithRawNote = {
+        ...weeklySummaryInput,
+        rawNoteText: "private workout note text",
+        note: "another private note",
+        notes: [{ note: "nested private note" }],
+      } as unknown as WeeklySummaryInput;
+      const payload = buildPayload({ weeklySummaryInput: inputWithRawNote });
+      const messages = toWeeklySummaryPromptMessages(payload);
+      const serialized = JSON.stringify({ payload, messages });
+
+      expect(serialized).not.toContain("private workout note text");
+      expect(serialized).not.toContain("another private note");
+      expect(serialized).not.toContain("nested private note");
+    });
+
+    it("does not mutate input data", () => {
+      const promptInput: WeeklySummaryPromptInput = {
+        weeklySummaryInput,
+        locale: "en",
+        tone: "analytical",
+      };
+      const original = JSON.parse(JSON.stringify(promptInput));
+
+      buildWeeklySummaryPromptPayload(promptInput);
+
+      expect(promptInput).toEqual(original);
+    });
+
+    it("returns deterministic output for the same input", () => {
+      expect(buildPayload()).toEqual(buildPayload());
+    });
+
+    it("uses en and concise as default locale and tone", () => {
+      const payload = buildPayload();
+
+      expect(payload.task).toContain("Write the output values in English.");
+      expect(payload.task).toContain("Keep the reflection short and direct.");
+    });
+
+    it("falls back to default locale and tone for unsupported runtime values", () => {
+      const payload = buildPayload({
+        locale: "fr" as never,
+        tone: "verbose" as never,
+      });
+
+      expect(payload.task).toContain("Write the output values in English.");
+      expect(payload.task).toContain("Keep the reflection short and direct.");
+    });
+
+    it("keeps safety rules when ja locale is selected", () => {
+      const payload = buildPayload({ locale: "ja" });
+
+      expect(payload.task).toContain("Write the output values in Japanese");
+      expect(payload.system).toContain("not a medical professional");
+      expect(payload.constraints).toContain("Do not give medical advice.");
+      expect(payload.constraints).toContain("Do not diagnose injuries.");
+    });
+
+    it("keeps safety rules for analytical and coach_like tones", () => {
+      const analyticalPayload = buildPayload({ tone: "analytical" });
+      const coachLikePayload = buildPayload({ tone: "coach_like" });
+
+      expect(analyticalPayload.task).toContain("Emphasize concrete metrics");
+      expect(analyticalPayload.constraints).toContain("Do not prescribe a fixed training program.");
+      expect(coachLikePayload.task).toContain("Use supportive language");
+      expect(coachLikePayload.constraints).toContain("Do not prescribe a fixed training program.");
+    });
+  });
+
+  describe("toWeeklySummaryPromptMessages", () => {
+    it("converts prompt payload to provider-neutral system and user messages", () => {
+      const payload = buildPayload();
+      const messages = toWeeklySummaryPromptMessages(payload);
+
+      expect(messages).toEqual([
+        {
+          role: "system",
+          content: payload.system,
+        },
+        {
+          role: "user",
+          content: expect.any(String),
+        },
+      ]);
+      expect(messages[1].content).toContain("TASK:");
+      expect(messages[1].content).toContain("CONSTRAINTS:");
+      expect(messages[1].content).toContain("DATA INTERPRETATION RULES:");
+      expect(messages[1].content).toContain("OUTPUT FORMAT:");
+      expect(messages[1].content).toContain("DATA:");
+    });
+
+    it("includes weekly summary data JSON in the user message", () => {
+      const messages = toWeeklySummaryPromptMessages(buildPayload());
+
+      expect(messages[1].content).toContain('"rangeStart": "2026-06-01"');
+      expect(messages[1].content).toContain('"totalSets": 12');
+      expect(messages[1].content).toContain('"averageRpe": 8.1');
+    });
+
+    it("does not add provider-specific fields", () => {
+      const payload = buildPayload();
+      const messages = toWeeklySummaryPromptMessages(payload);
+      const serialized = JSON.stringify({ payload, messages });
+
+      expect(Object.keys(payload)).toEqual([
+        "system",
+        "task",
+        "constraints",
+        "dataInterpretationRules",
+        "outputFormat",
+        "data",
+      ]);
+      expect(serialized).not.toContain("model");
+      expect(serialized).not.toContain("temperature");
+      expect(serialized).not.toContain("max_tokens");
+    });
+
+    it("does not include raw note text in messages", () => {
+      const inputWithRawNote = {
+        ...weeklySummaryInput,
+        rawNoteText: "private workout note text",
+      } as unknown as WeeklySummaryInput;
+      const payload = buildPayload({ weeklySummaryInput: inputWithRawNote });
+      const messages = toWeeklySummaryPromptMessages(payload);
+
+      expect(JSON.stringify(messages)).not.toContain("private workout note text");
+    });
+  });
+});

--- a/shared/utils/weeklySummaryPromptBuilder.ts
+++ b/shared/utils/weeklySummaryPromptBuilder.ts
@@ -1,0 +1,237 @@
+import type {
+  WeeklySummaryBig3Input,
+  WeeklySummaryInput,
+  WeeklySummaryMuscleGroupInput,
+} from "./weeklySummaryInput";
+
+export type WeeklySummaryPromptTone = "concise" | "coach_like" | "analytical";
+export type WeeklySummaryPromptLocale = "en" | "ja";
+
+export type WeeklySummaryPromptInput = {
+  weeklySummaryInput: WeeklySummaryInput;
+  locale?: WeeklySummaryPromptLocale;
+  tone?: WeeklySummaryPromptTone;
+};
+
+export type WeeklySummaryPromptPayload = {
+  system: string;
+  task: string;
+  constraints: string[];
+  dataInterpretationRules: string[];
+  outputFormat: string;
+  data: WeeklySummaryInput;
+};
+
+export type WeeklySummaryPromptMessage = {
+  role: "system" | "user";
+  content: string;
+};
+
+const DEFAULT_LOCALE: WeeklySummaryPromptLocale = "en";
+const DEFAULT_TONE: WeeklySummaryPromptTone = "concise";
+
+const SYSTEM_INSTRUCTION = [
+  "You summarize workout analytics data.",
+  "You are not a medical professional and must not diagnose injuries or prescribe treatment.",
+  "Use only the provided data.",
+  "Mention uncertainty when data is sparse.",
+  "Do not invent exercises, dates, weights, PRs, pain, injuries, or goals.",
+].join(" ");
+
+const BASE_CONSTRAINTS = [
+  "Use only the provided aggregate data.",
+  "Missing values are unknown.",
+  "Missing effort values are not low effort.",
+  "Do not give medical advice.",
+  "Do not diagnose injuries.",
+  "Do not prescribe a fixed training program.",
+  "Do not infer user goals.",
+  "Keep the output concise.",
+  "Return JSON-compatible structured output.",
+];
+
+const DATA_INTERPRETATION_RULES = [
+  "failure count means failure === true only.",
+  "Sparse effort coverage lowers confidence.",
+  "No BIG3 data means no strength trend conclusion.",
+  "No muscle group data means no volume balance conclusion.",
+  "No notes or no sets means a cautious summary.",
+  "Raw note text is not provided.",
+];
+
+const OUTPUT_FORMAT = [
+  "Return JSON-compatible structured output with these fields:",
+  "- headline: string",
+  "- summary: string",
+  "- highlights: string[]",
+  "- concerns: string[]",
+  "- nextWeekFocus: string[]",
+  "- dataQualityNotes: string[]",
+  "Empty arrays are allowed.",
+  "Do not include markdown.",
+  "Do not invent data.",
+].join("\n");
+
+const TONE_INSTRUCTIONS: Record<WeeklySummaryPromptTone, string> = {
+  analytical: "Emphasize concrete metrics and uncertainty without overexplaining.",
+  coach_like: "Use supportive language, but do not prescribe a fixed training program.",
+  concise: "Keep the reflection short and direct.",
+};
+
+const LOCALE_INSTRUCTIONS: Record<WeeklySummaryPromptLocale, string> = {
+  en: "Write the output values in English.",
+  ja: "Write the output values in Japanese, but keep JSON field names in English.",
+};
+
+const isFiniteNumber = (value: number | null | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+const toNonNegativeCount = (value: number | null | undefined): number => (
+  isFiniteNumber(value) && value > 0 ? Math.floor(value) : 0
+);
+
+const toNonNegativeNumber = (value: number | null | undefined): number => (
+  isFiniteNumber(value) && value > 0 ? value : 0
+);
+
+const toFiniteNumberOrNull = (value: number | null | undefined): number | null => (
+  isFiniteNumber(value) ? value : null
+);
+
+const toText = (value: string | null | undefined): string => (
+  typeof value === "string" ? value : ""
+);
+
+const resolveLocale = (
+  locale: WeeklySummaryPromptLocale | undefined
+): WeeklySummaryPromptLocale => (
+  locale === "ja" || locale === "en" ? locale : DEFAULT_LOCALE
+);
+
+const resolveTone = (
+  tone: WeeklySummaryPromptTone | undefined
+): WeeklySummaryPromptTone => (
+  tone === "analytical" || tone === "coach_like" || tone === "concise"
+    ? tone
+    : DEFAULT_TONE
+);
+
+const sanitizeBig3 = (
+  big3: WeeklySummaryBig3Input[]
+): WeeklySummaryBig3Input[] => {
+  if (!Array.isArray(big3)) {
+    return [];
+  }
+
+  return big3.map((summary) => ({
+    lift: toText(summary.lift),
+    latestEstimatedOneRepMax: toFiniteNumberOrNull(summary.latestEstimatedOneRepMax),
+    maxEstimatedOneRepMax: toFiniteNumberOrNull(summary.maxEstimatedOneRepMax),
+    trendPointCount: toNonNegativeCount(summary.trendPointCount),
+  }));
+};
+
+const sanitizeMuscleGroups = (
+  muscleGroups: WeeklySummaryMuscleGroupInput[]
+): WeeklySummaryMuscleGroupInput[] => {
+  if (!Array.isArray(muscleGroups)) {
+    return [];
+  }
+
+  return muscleGroups.map((group) => ({
+    muscle: toText(group.muscle),
+    totalSets: toNonNegativeNumber(group.totalSets),
+    totalVolumeLoad: toNonNegativeNumber(group.totalVolumeLoad),
+  }));
+};
+
+const sanitizeDataQualityNotes = (notes: string[]): string[] => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  return notes.filter((note) => typeof note === "string");
+};
+
+const sanitizeWeeklySummaryInput = (
+  input: WeeklySummaryInput
+): WeeklySummaryInput => ({
+  rangeStart: toText(input.rangeStart),
+  rangeEnd: toText(input.rangeEnd),
+  totalNotes: toNonNegativeCount(input.totalNotes),
+  totalSets: toNonNegativeCount(input.totalSets),
+  big3: sanitizeBig3(input.big3),
+  muscleGroups: sanitizeMuscleGroups(input.muscleGroups),
+  effort: {
+    totalSetCount: toNonNegativeCount(input.effort.totalSetCount),
+    effortLoggedSetCount: toNonNegativeCount(input.effort.effortLoggedSetCount),
+    rpeCount: toNonNegativeCount(input.effort.rpeCount),
+    averageRpe: toFiniteNumberOrNull(input.effort.averageRpe),
+    rirCount: toNonNegativeCount(input.effort.rirCount),
+    averageRir: toFiniteNumberOrNull(input.effort.averageRir),
+    failureCount: toNonNegativeCount(input.effort.failureCount),
+  },
+  dataQualityNotes: sanitizeDataQualityNotes(input.dataQualityNotes),
+});
+
+const buildTaskInstruction = (
+  locale: WeeklySummaryPromptLocale,
+  tone: WeeklySummaryPromptTone
+): string => [
+  "Summarize the weekly workout analytics data as a concise weekly reflection.",
+  LOCALE_INSTRUCTIONS[locale],
+  TONE_INSTRUCTIONS[tone],
+  "Separate achievements, concerns, and next focus.",
+].join(" ");
+
+export const buildWeeklySummaryPromptPayload = (
+  input: WeeklySummaryPromptInput
+): WeeklySummaryPromptPayload => {
+  const locale = resolveLocale(input.locale);
+  const tone = resolveTone(input.tone);
+
+  return {
+    system: SYSTEM_INSTRUCTION,
+    task: buildTaskInstruction(locale, tone),
+    constraints: [...BASE_CONSTRAINTS],
+    dataInterpretationRules: [...DATA_INTERPRETATION_RULES],
+    outputFormat: OUTPUT_FORMAT,
+    data: sanitizeWeeklySummaryInput(input.weeklySummaryInput),
+  };
+};
+
+const formatListSection = (title: string, items: string[]): string => [
+  `${title}:`,
+  ...items.map((item) => `- ${item}`),
+].join("\n");
+
+export const toWeeklySummaryPromptMessages = (
+  payload: WeeklySummaryPromptPayload
+): WeeklySummaryPromptMessage[] => {
+  const userContent = [
+    "TASK:",
+    payload.task,
+    "",
+    formatListSection("CONSTRAINTS", payload.constraints),
+    "",
+    formatListSection("DATA INTERPRETATION RULES", payload.dataInterpretationRules),
+    "",
+    "OUTPUT FORMAT:",
+    payload.outputFormat,
+    "",
+    "DATA:",
+    JSON.stringify(payload.data, null, 2),
+  ].join("\n");
+
+  return [
+    {
+      role: "system",
+      content: payload.system,
+    },
+    {
+      role: "user",
+      content: userContent,
+    },
+  ];
+};


### PR DESCRIPTION
## Summary
- Added provider-neutral weekly summary prompt builder
- Added `buildWeeklySummaryPromptPayload`
- Added `toWeeklySummaryPromptMessages`
- Builds structured prompt payloads from `WeeklySummaryInput`
- Includes system, task, safety constraints, data interpretation rules, output format, and structured data
- Excludes raw note text
- Added tests for required sections, safety rules, interpretation rules, output fields, deterministic output, non-mutation, locale/tone handling, and provider-neutral messages
- Updated verification docs

## Verification
- `npm test` passed
  - 21 test suites passed
  - 230 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No external AI API integration
- No API keys or env changes
- No backend endpoint changes
- No DB changes
- No UI changes
- No backend service changes
- No provider SDK added