### PR TITLE
Add weekly summary response validation

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -49,6 +49,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Analytics displays a deterministic rule-based weekly summary preview without calling an AI API.
 - Shared weekly summary prompt builder tests are included in `npm test` and CI.
 - Weekly summary prompt builder creates provider-neutral prompt payloads without calling an external AI API.
+- Shared weekly summary response validation tests are included in `npm test` and CI.
+- Weekly summary response validation safely validates structured weekly summary responses before future AI rendering.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
@@ -75,7 +77,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add backend AI endpoint design, weekly summary response validation helper, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after backend design and response validation.
+- Add backend AI endpoint design, backend AI endpoint implementation with mocked provider tests, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after backend design and mocked endpoint tests.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/weeklySummaryResponseValidation.spec.ts
+++ b/shared/utils/__tests__/weeklySummaryResponseValidation.spec.ts
@@ -1,0 +1,241 @@
+import {
+  createEmptyWeeklySummaryResponse,
+  parseAndValidateWeeklySummaryResponse,
+  validateWeeklySummaryResponse,
+  type WeeklySummaryValidatedResponse,
+} from "../weeklySummaryResponseValidation";
+
+const validResponse: WeeklySummaryValidatedResponse = {
+  headline: "Solid training week",
+  summary: "You logged a consistent week with useful effort data.",
+  highlights: ["Bench Press max estimated 1RM: 100."],
+  concerns: ["Effort coverage is partial."],
+  nextWeekFocus: ["Keep logging RPE/RIR."],
+  dataQualityNotes: [],
+};
+
+const fallback: WeeklySummaryValidatedResponse = {
+  headline: "Fallback summary",
+  summary: "Using fallback weekly summary.",
+  highlights: ["Fallback highlight."],
+  concerns: ["Fallback concern."],
+  nextWeekFocus: ["Fallback focus."],
+  dataQualityNotes: ["Fallback data quality note."],
+};
+
+const longString = (length: number): string => "x".repeat(length);
+
+describe("weeklySummaryResponseValidation", () => {
+  describe("createEmptyWeeklySummaryResponse", () => {
+    it("creates a safe default fallback response", () => {
+      expect(createEmptyWeeklySummaryResponse()).toEqual({
+        headline: "Weekly summary unavailable",
+        summary: "The weekly summary could not be validated.",
+        highlights: [],
+        concerns: [],
+        nextWeekFocus: [],
+        dataQualityNotes: ["Weekly summary response validation failed."],
+      });
+    });
+  });
+
+  describe("validateWeeklySummaryResponse", () => {
+    it("accepts a valid structured response", () => {
+      expect(validateWeeklySummaryResponse(validResponse, fallback)).toEqual({
+        ok: true,
+        value: validResponse,
+        errors: [],
+      });
+    });
+
+    it("accepts empty arrays as valid", () => {
+      const response: WeeklySummaryValidatedResponse = {
+        headline: "Empty sections",
+        summary: "All list sections are empty.",
+        highlights: [],
+        concerns: [],
+        nextWeekFocus: [],
+        dataQualityNotes: [],
+      };
+
+      expect(validateWeeklySummaryResponse(response, fallback)).toEqual({
+        ok: true,
+        value: response,
+        errors: [],
+      });
+    });
+
+    it("ignores extra fields on a valid response", () => {
+      const response = {
+        ...validResponse,
+        extra: "ignored",
+      };
+      const result = validateWeeklySummaryResponse(response, fallback);
+
+      expect(result.ok).toBe(true);
+      expect(result.value).toEqual(validResponse);
+      expect("extra" in result.value).toBe(false);
+    });
+
+    it("rejects a response with a missing required field and returns fallback", () => {
+      const { summary, ...response } = validResponse;
+      const result = validateWeeklySummaryResponse(response, fallback);
+
+      expect(result).toEqual({
+        ok: false,
+        value: fallback,
+        errors: ["Missing required field: summary."],
+      });
+    });
+
+    it("rejects wrong field types and returns fallback", () => {
+      const result = validateWeeklySummaryResponse({
+        ...validResponse,
+        headline: 123,
+      }, fallback);
+
+      expect(result.ok).toBe(false);
+      expect(result.value).toEqual(fallback);
+      expect(result.errors).toContain("Invalid field type: headline must be a string.");
+    });
+
+    it("rejects non-string array items and returns fallback", () => {
+      const result = validateWeeklySummaryResponse({
+        ...validResponse,
+        highlights: ["ok", 123],
+      }, fallback);
+
+      expect(result.ok).toBe(false);
+      expect(result.value).toEqual(fallback);
+      expect(result.errors).toContain("Invalid array item: highlights[1] must be a string.");
+    });
+
+    it("rejects arrays with too many items and returns fallback", () => {
+      const result = validateWeeklySummaryResponse({
+        ...validResponse,
+        concerns: Array.from({ length: 9 }, (_, index) => `concern-${index}`),
+      }, fallback);
+
+      expect(result.ok).toBe(false);
+      expect(result.value).toEqual(fallback);
+      expect(result.errors).toContain("Too many items: concerns must contain at most 8 items.");
+    });
+
+    it("rejects overly long response strings and returns fallback", () => {
+      const result = validateWeeklySummaryResponse({
+        ...validResponse,
+        headline: longString(121),
+        summary: longString(1001),
+        nextWeekFocus: [longString(301)],
+      }, fallback);
+
+      expect(result.ok).toBe(false);
+      expect(result.value).toEqual(fallback);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        "String too long: headline must be at most 120 characters.",
+        "String too long: summary must be at most 1000 characters.",
+        "String too long: nextWeekFocus[0] must be at most 300 characters.",
+      ]));
+    });
+
+    it("normalizes overly long fallback content deterministically", () => {
+      const longFallback: WeeklySummaryValidatedResponse = {
+        headline: longString(121),
+        summary: longString(1001),
+        highlights: Array.from({ length: 9 }, () => longString(301)),
+        concerns: [],
+        nextWeekFocus: [],
+        dataQualityNotes: [],
+      };
+      const result = validateWeeklySummaryResponse({ headline: 123 }, longFallback);
+
+      expect(result.ok).toBe(false);
+      expect(result.value.headline).toHaveLength(120);
+      expect(result.value.summary).toHaveLength(1000);
+      expect(result.value.highlights).toHaveLength(8);
+      expect(result.value.highlights[0]).toHaveLength(300);
+    });
+
+    it("uses the safe default when fallback is invalid", () => {
+      const result = validateWeeklySummaryResponse(
+        { headline: 123 },
+        {
+          ...fallback,
+          highlights: ["ok", 123],
+        } as unknown as WeeklySummaryValidatedResponse
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.value).toEqual(createEmptyWeeklySummaryResponse());
+    });
+
+    it("does not mutate response or fallback input", () => {
+      const response = { ...validResponse };
+      const fallbackInput = { ...fallback };
+      const originalResponse = JSON.parse(JSON.stringify(response));
+      const originalFallback = JSON.parse(JSON.stringify(fallbackInput));
+
+      validateWeeklySummaryResponse(response, fallbackInput);
+
+      expect(response).toEqual(originalResponse);
+      expect(fallbackInput).toEqual(originalFallback);
+    });
+
+    it("returns deterministic output", () => {
+      expect(validateWeeklySummaryResponse(validResponse, fallback)).toEqual(
+        validateWeeklySummaryResponse(validResponse, fallback)
+      );
+    });
+  });
+
+  describe("parseAndValidateWeeklySummaryResponse", () => {
+    it("accepts a valid JSON string response", () => {
+      expect(
+        parseAndValidateWeeklySummaryResponse(JSON.stringify(validResponse), fallback)
+      ).toEqual({
+        ok: true,
+        value: validResponse,
+        errors: [],
+      });
+    });
+
+    it("returns fallback on invalid JSON", () => {
+      const result = parseAndValidateWeeklySummaryResponse("{invalid", fallback);
+
+      expect(result).toEqual({
+        ok: false,
+        value: fallback,
+        errors: ["JSON parse error."],
+      });
+    });
+
+    it("rejects JSON array, number, and string roots", () => {
+      expect(parseAndValidateWeeklySummaryResponse("[]", fallback)).toMatchObject({
+        ok: false,
+        value: fallback,
+        errors: ["Response must be an object."],
+      });
+      expect(parseAndValidateWeeklySummaryResponse("1", fallback)).toMatchObject({
+        ok: false,
+        value: fallback,
+        errors: ["Response must be an object."],
+      });
+      expect(parseAndValidateWeeklySummaryResponse("\"text\"", fallback)).toMatchObject({
+        ok: false,
+        value: fallback,
+        errors: ["Response must be an object."],
+      });
+    });
+
+    it("returns fallback when JSON object has an invalid shape", () => {
+      const result = parseAndValidateWeeklySummaryResponse(
+        JSON.stringify({ ...validResponse, highlights: [1] }),
+        fallback
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.value).toEqual(fallback);
+      expect(result.errors).toContain("Invalid array item: highlights[0] must be a string.");
+    });
+  });
+});

--- a/shared/utils/weeklySummaryResponseValidation.ts
+++ b/shared/utils/weeklySummaryResponseValidation.ts
@@ -1,0 +1,273 @@
+export type WeeklySummaryValidatedResponse = {
+  headline: string;
+  summary: string;
+  highlights: string[];
+  concerns: string[];
+  nextWeekFocus: string[];
+  dataQualityNotes: string[];
+};
+
+export type WeeklySummaryResponseValidationResult =
+  | {
+      ok: true;
+      value: WeeklySummaryValidatedResponse;
+      errors: [];
+    }
+  | {
+      ok: false;
+      value: WeeklySummaryValidatedResponse;
+      errors: string[];
+    };
+
+type StringField = "headline" | "summary";
+type ArrayField = "highlights" | "concerns" | "nextWeekFocus" | "dataQualityNotes";
+
+const HEADLINE_MAX_LENGTH = 120;
+const SUMMARY_MAX_LENGTH = 1000;
+const ARRAY_ITEM_MAX_LENGTH = 300;
+const ARRAY_MAX_ITEMS = 8;
+
+const STRING_FIELD_LIMITS: Record<StringField, number> = {
+  headline: HEADLINE_MAX_LENGTH,
+  summary: SUMMARY_MAX_LENGTH,
+};
+
+const ARRAY_FIELDS: ArrayField[] = [
+  "highlights",
+  "concerns",
+  "nextWeekFocus",
+  "dataQualityNotes",
+];
+
+export const createEmptyWeeklySummaryResponse = (): WeeklySummaryValidatedResponse => ({
+  headline: "Weekly summary unavailable",
+  summary: "The weekly summary could not be validated.",
+  highlights: [],
+  concerns: [],
+  nextWeekFocus: [],
+  dataQualityNotes: ["Weekly summary response validation failed."],
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === "object" && value !== null && !Array.isArray(value)
+);
+
+const truncate = (value: string, maxLength: number): string => (
+  value.length > maxLength ? value.slice(0, maxLength) : value
+);
+
+const normalizeFallbackArray = (
+  value: unknown
+): string[] | null => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  if (value.some((item) => typeof item !== "string")) {
+    return null;
+  }
+
+  return value
+    .slice(0, ARRAY_MAX_ITEMS)
+    .map((item) => truncate(item, ARRAY_ITEM_MAX_LENGTH));
+};
+
+const normalizeFallback = (fallback: unknown): WeeklySummaryValidatedResponse => {
+  const empty = createEmptyWeeklySummaryResponse();
+
+  if (!isRecord(fallback)) {
+    return empty;
+  }
+
+  if (
+    typeof fallback.headline !== "string" ||
+    typeof fallback.summary !== "string"
+  ) {
+    return empty;
+  }
+
+  const normalizedArrays = ARRAY_FIELDS.reduce<Partial<Record<ArrayField, string[]>>>(
+    (result, field) => {
+      const normalized = normalizeFallbackArray(fallback[field]);
+      if (normalized === null) {
+        return result;
+      }
+
+      return {
+        ...result,
+        [field]: normalized,
+      };
+    },
+    {}
+  );
+
+  if (ARRAY_FIELDS.some((field) => normalizedArrays[field] === undefined)) {
+    return empty;
+  }
+
+  return {
+    headline: truncate(fallback.headline, HEADLINE_MAX_LENGTH),
+    summary: truncate(fallback.summary, SUMMARY_MAX_LENGTH),
+    highlights: normalizedArrays.highlights ?? [],
+    concerns: normalizedArrays.concerns ?? [],
+    nextWeekFocus: normalizedArrays.nextWeekFocus ?? [],
+    dataQualityNotes: normalizedArrays.dataQualityNotes ?? [],
+  };
+};
+
+const validateStringField = (
+  response: Record<string, unknown>,
+  field: StringField,
+  errors: string[]
+): string | null => {
+  if (!(field in response)) {
+    errors.push(`Missing required field: ${field}.`);
+    return null;
+  }
+
+  const value = response[field];
+  if (typeof value !== "string") {
+    errors.push(`Invalid field type: ${field} must be a string.`);
+    return null;
+  }
+
+  const limit = STRING_FIELD_LIMITS[field];
+  if (value.length > limit) {
+    errors.push(`String too long: ${field} must be at most ${limit} characters.`);
+    return null;
+  }
+
+  return value;
+};
+
+const validateArrayField = (
+  response: Record<string, unknown>,
+  field: ArrayField,
+  errors: string[]
+): string[] | null => {
+  if (!(field in response)) {
+    errors.push(`Missing required field: ${field}.`);
+    return null;
+  }
+
+  const value = response[field];
+  if (!Array.isArray(value)) {
+    errors.push(`Invalid field type: ${field} must be a string array.`);
+    return null;
+  }
+
+  if (value.length > ARRAY_MAX_ITEMS) {
+    errors.push(`Too many items: ${field} must contain at most ${ARRAY_MAX_ITEMS} items.`);
+    return null;
+  }
+
+  const invalidItemIndex = value.findIndex((item) => typeof item !== "string");
+  if (invalidItemIndex !== -1) {
+    errors.push(`Invalid array item: ${field}[${invalidItemIndex}] must be a string.`);
+    return null;
+  }
+
+  const tooLongIndex = value.findIndex((item) => item.length > ARRAY_ITEM_MAX_LENGTH);
+  if (tooLongIndex !== -1) {
+    errors.push(
+      `String too long: ${field}[${tooLongIndex}] must be at most ${ARRAY_ITEM_MAX_LENGTH} characters.`
+    );
+    return null;
+  }
+
+  return [...value];
+};
+
+const validateResponseShape = (
+  response: unknown
+): { value: WeeklySummaryValidatedResponse | null; errors: string[] } => {
+  const errors: string[] = [];
+
+  if (!isRecord(response)) {
+    return {
+      value: null,
+      errors: ["Response must be an object."],
+    };
+  }
+
+  const headline = validateStringField(response, "headline", errors);
+  const summary = validateStringField(response, "summary", errors);
+  const highlights = validateArrayField(response, "highlights", errors);
+  const concerns = validateArrayField(response, "concerns", errors);
+  const nextWeekFocus = validateArrayField(response, "nextWeekFocus", errors);
+  const dataQualityNotes = validateArrayField(response, "dataQualityNotes", errors);
+
+  if (
+    errors.length > 0 ||
+    headline === null ||
+    summary === null ||
+    highlights === null ||
+    concerns === null ||
+    nextWeekFocus === null ||
+    dataQualityNotes === null
+  ) {
+    return {
+      value: null,
+      errors,
+    };
+  }
+
+  return {
+    value: {
+      headline,
+      summary,
+      highlights,
+      concerns,
+      nextWeekFocus,
+      dataQualityNotes,
+    },
+    errors: [],
+  };
+};
+
+export const validateWeeklySummaryResponse = (
+  response: unknown,
+  fallback: WeeklySummaryValidatedResponse
+): WeeklySummaryResponseValidationResult => {
+  const fallbackValue = normalizeFallback(fallback);
+  const result = validateResponseShape(response);
+
+  if (result.value !== null) {
+    return {
+      ok: true,
+      value: result.value,
+      errors: [],
+    };
+  }
+
+  return {
+    ok: false,
+    value: fallbackValue,
+    errors: result.errors.length > 0
+      ? result.errors
+      : ["Weekly summary response validation failed."],
+  };
+};
+
+export const parseAndValidateWeeklySummaryResponse = (
+  responseText: string,
+  fallback: WeeklySummaryValidatedResponse
+): WeeklySummaryResponseValidationResult => {
+  if (typeof responseText !== "string") {
+    return {
+      ok: false,
+      value: normalizeFallback(fallback),
+      errors: ["Response text must be a string."],
+    };
+  }
+
+  try {
+    return validateWeeklySummaryResponse(JSON.parse(responseText), fallback);
+  } catch {
+    return {
+      ok: false,
+      value: normalizeFallback(fallback),
+      errors: ["JSON parse error."],
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- Added weekly summary response validation helper
- Added `createEmptyWeeklySummaryResponse`
- Added `validateWeeklySummaryResponse`
- Added `parseAndValidateWeeklySummaryResponse`
- Validates structured weekly summary responses before future AI rendering
- Returns safe fallback responses for invalid shapes or parse failures
- Enforces required fields, string arrays, array limits, and string length limits
- Added tests for valid responses, invalid shapes, parse failures, fallback normalization, non-mutation, and deterministic output
- Updated verification docs

## Verification
- `npm test` passed
  - 22 test suites passed
  - 247 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No external AI API integration
- No API keys or env changes
- No backend endpoint changes
- No DB changes
- No UI changes
- No backend service changes
- No provider SDK added