### PR TITLE
Add backend weekly summary endpoint skeleton

### DIFF
--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const {
+  handleGenerateWeeklySummary,
+} = require("../services/weeklySummaryService");
+
+const router = express.Router();
+
+router.post("/weekly-summary", handleGenerateWeeklySummary);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const authRoutes = require("./routes/authRoutes");
 const notesRoutes = require("./routes/noteRoutes");
+const analyticsRoutes = require("./routes/analyticsRoutes");
 
 const app = express();
 // 全ルートのログを出力
@@ -48,6 +49,8 @@ app.use(cookieParser());
 app.use("/auth", authRoutes);
 
 app.use("/notes", notesRoutes);
+
+app.use("/analytics", analyticsRoutes);
 
 // 404エラーハンドリング
 app.use((req, res, next) => {

--- a/backend/services/__tests__/weeklySummaryService.spec.js
+++ b/backend/services/__tests__/weeklySummaryService.spec.js
@@ -1,0 +1,265 @@
+/** @jest-environment node */
+
+const verifyToken = jest.fn();
+
+jest.mock("../../utils/authUtils", () => ({
+  verifyToken,
+}));
+
+const {
+  SUMMARY_SOURCE_AI,
+  SUMMARY_SOURCE_FALLBACK,
+  buildWeeklySummaryPromptMessages,
+  generateWeeklySummary,
+  handleGenerateWeeklySummary,
+} = require("../weeklySummaryService");
+
+const createResponse = () => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+const createSummaryInput = () => ({
+  rangeStart: "2026-06-01",
+  rangeEnd: "2026-06-07",
+  totalNotes: 3,
+  totalSets: 42,
+  big3: [],
+  muscleGroups: [],
+  effort: {
+    totalSetCount: 42,
+    effortLoggedSetCount: 12,
+    rpeCount: 10,
+    averageRpe: 8.1,
+    rirCount: 8,
+    averageRir: 1.5,
+    failureCount: 2,
+  },
+  dataQualityNotes: [],
+});
+
+const createValidProviderResponse = () => JSON.stringify({
+  headline: "Provider weekly summary",
+  summary: "Provider summary text.",
+  highlights: ["42 sets logged."],
+  concerns: [],
+  nextWeekFocus: ["Keep logging effort."],
+  dataQualityNotes: [],
+});
+
+describe("weeklySummaryService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("buildWeeklySummaryPromptMessages", () => {
+    it("builds provider-neutral system and user messages", () => {
+      const messages = buildWeeklySummaryPromptMessages({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toEqual({
+        role: "system",
+        content: expect.stringContaining("Use only the provided aggregate data."),
+      });
+      expect(messages[1].role).toBe("user");
+      expect(messages[1].content).toContain("TASK:");
+      expect(messages[1].content).toContain("CONSTRAINTS:");
+      expect(messages[1].content).toContain("DATA:");
+      expect(messages[1].content).not.toContain("rawNoteText");
+      expect(messages[1]).not.toHaveProperty("model");
+      expect(messages[1]).not.toHaveProperty("temperature");
+    });
+  });
+
+  describe("generateWeeklySummary", () => {
+    it("returns source ai when the mocked provider returns a valid response", async () => {
+      const provider = {
+        generateWeeklySummary: jest.fn().mockResolvedValue(createValidProviderResponse()),
+      };
+
+      const result = await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+        provider,
+      });
+
+      expect(provider.generateWeeklySummary).toHaveBeenCalledWith(expect.any(Array));
+      expect(result).toEqual({
+        source: SUMMARY_SOURCE_AI,
+        summary: {
+          headline: "Provider weekly summary",
+          summary: "Provider summary text.",
+          highlights: ["42 sets logged."],
+          concerns: [],
+          nextWeekFocus: ["Keep logging effort."],
+          dataQualityNotes: [],
+        },
+        validationErrors: [],
+      });
+    });
+
+    it("returns rule_based_fallback when the provider returns invalid JSON", async () => {
+      const provider = {
+        generateWeeklySummary: jest.fn().mockResolvedValue("{not-json"),
+      };
+
+      const result = await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+        provider,
+      });
+
+      expect(result.source).toBe(SUMMARY_SOURCE_FALLBACK);
+      expect(result.summary.headline).toBe("Weekly training summary");
+      expect(result.validationErrors).toContain("JSON parse error.");
+    });
+
+    it("returns rule_based_fallback when the provider returns an invalid shape", async () => {
+      const provider = {
+        generateWeeklySummary: jest.fn().mockResolvedValue(JSON.stringify({
+          headline: "Missing arrays",
+          summary: "Invalid shape.",
+        })),
+      };
+
+      const result = await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+        provider,
+      });
+
+      expect(result.source).toBe(SUMMARY_SOURCE_FALLBACK);
+      expect(result.validationErrors).toEqual(expect.arrayContaining([
+        "Missing required field: highlights.",
+        "Missing required field: concerns.",
+        "Missing required field: nextWeekFocus.",
+        "Missing required field: dataQualityNotes.",
+      ]));
+    });
+
+    it("returns rule_based_fallback when the provider throws", async () => {
+      const provider = {
+        generateWeeklySummary: jest.fn().mockRejectedValue(new Error("provider failed")),
+      };
+
+      const result = await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+        provider,
+      });
+
+      expect(result.source).toBe(SUMMARY_SOURCE_FALLBACK);
+      expect(result.validationErrors).toEqual(["Provider request failed."]);
+    });
+
+    it("does not mutate input", async () => {
+      const provider = {
+        generateWeeklySummary: jest.fn().mockResolvedValue(createValidProviderResponse()),
+      };
+      const summaryInput = createSummaryInput();
+      const original = JSON.parse(JSON.stringify(summaryInput));
+
+      await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput,
+        provider,
+      });
+
+      expect(summaryInput).toEqual(original);
+    });
+  });
+
+  describe("handleGenerateWeeklySummary", () => {
+    it("returns 401 when Authorization token is missing", async () => {
+      const req = {
+        headers: {},
+        body: {},
+      };
+      const res = createResponse();
+
+      await handleGenerateWeeklySummary(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "Authorization token missing" });
+      expect(verifyToken).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when verifyToken returns null", async () => {
+      verifyToken.mockResolvedValue(null);
+      const req = {
+        headers: { authorization: "Bearer invalid-token" },
+        body: {},
+      };
+      const res = createResponse();
+
+      await handleGenerateWeeklySummary(req, res);
+
+      expect(verifyToken).toHaveBeenCalledWith("invalid-token");
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ error: "Invalid token" });
+    });
+
+    it("returns 400 for an invalid request", async () => {
+      verifyToken.mockResolvedValue({ id: "user-123" });
+      const req = {
+        headers: { authorization: "Bearer valid-token" },
+        body: {
+          rangeStart: "2026-06-07",
+          rangeEnd: "2026-06-01",
+          summaryInput: {},
+        },
+      };
+      const res = createResponse();
+
+      await handleGenerateWeeklySummary(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "Invalid weekly summary request",
+        details: ["rangeEnd must be on or after rangeStart."],
+      });
+    });
+
+    it("returns a mocked provider summary for a valid authenticated request", async () => {
+      verifyToken.mockResolvedValue({ id: "user-123" });
+      const req = {
+        headers: { authorization: "Bearer valid-token" },
+        body: {
+          rangeStart: "2026-06-01",
+          rangeEnd: "2026-06-07",
+          summaryInput: createSummaryInput(),
+        },
+      };
+      const res = createResponse();
+
+      await handleGenerateWeeklySummary(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        source: SUMMARY_SOURCE_AI,
+        summary: {
+          headline: "Mock weekly summary",
+          summary: "This is a mocked weekly summary response.",
+          highlights: [],
+          concerns: [],
+          nextWeekFocus: [],
+          dataQualityNotes: [],
+        },
+        validationErrors: [],
+      });
+    });
+  });
+});

--- a/backend/services/weeklySummaryService.js
+++ b/backend/services/weeklySummaryService.js
@@ -1,0 +1,215 @@
+const { verifyToken } = require("../utils/authUtils");
+const {
+  validateWeeklySummaryRequest,
+} = require("../utils/weeklySummaryRequestValidation");
+const {
+  parseAndValidateWeeklySummaryResponse,
+} = require("../utils/weeklySummaryResponseValidation");
+const {
+  weeklySummaryMockProvider,
+} = require("../utils/weeklySummaryMockProvider");
+
+const SUMMARY_SOURCE_AI = "ai";
+const SUMMARY_SOURCE_FALLBACK = "rule_based_fallback";
+
+const isFiniteNumber = (value) => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+const toCount = (value) => (
+  isFiniteNumber(value) && value > 0 ? Math.floor(value) : 0
+);
+
+const getDataQualityNotes = (summaryInput) => (
+  Array.isArray(summaryInput.dataQualityNotes)
+    ? summaryInput.dataQualityNotes.filter((note) => typeof note === "string")
+    : []
+);
+
+const buildRuleBasedFallbackSummary = ({
+  rangeStart,
+  rangeEnd,
+  summaryInput,
+}) => {
+  const totalNotes = toCount(summaryInput.totalNotes);
+  const totalSets = toCount(summaryInput.totalSets);
+  const dataQualityNotes = getDataQualityNotes(summaryInput);
+
+  if (totalSets === 0) {
+    return {
+      headline: "No training data in this range",
+      summary: `No normalized training sets were found from ${rangeStart} to ${rangeEnd}.`,
+      highlights: [],
+      concerns: dataQualityNotes,
+      nextWeekFocus: ["Keep logging workouts to unlock weekly summaries."],
+      dataQualityNotes,
+    };
+  }
+
+  const effort = summaryInput.effort && typeof summaryInput.effort === "object"
+    ? summaryInput.effort
+    : {};
+  const effortLoggedSetCount = toCount(effort.effortLoggedSetCount);
+  const totalEffortSetCount = toCount(effort.totalSetCount);
+  const failureCount = toCount(effort.failureCount);
+
+  const highlights = [
+    `${totalNotes} workout notes produced ${totalSets} normalized sets.`,
+  ];
+
+  if (effortLoggedSetCount > 0) {
+    highlights.push(
+      `Effort coverage: ${effortLoggedSetCount} / ${totalEffortSetCount} sets.`
+    );
+  }
+
+  return {
+    headline: "Weekly training summary",
+    summary: `From ${rangeStart} to ${rangeEnd}, ${totalNotes} workout notes produced ${totalSets} normalized sets.`,
+    highlights,
+    concerns: dataQualityNotes,
+    nextWeekFocus: [
+      "Review top lifts, muscle group volume, and effort coverage before the next week.",
+    ],
+    dataQualityNotes: [
+      ...dataQualityNotes,
+      ...(failureCount > 0 ? [`Failure sets logged: ${failureCount}.`] : []),
+    ],
+  };
+};
+
+const buildWeeklySummaryPromptMessages = ({
+  rangeStart,
+  rangeEnd,
+  summaryInput,
+}) => [
+  {
+    role: "system",
+    content: [
+      "You summarize workout analytics data.",
+      "Use only the provided aggregate data.",
+      "Do not provide medical advice or diagnose injuries.",
+      "Do not invent exercises, dates, weights, PRs, pain, injuries, or goals.",
+      "Return JSON-compatible structured output.",
+    ].join(" "),
+  },
+  {
+    role: "user",
+    content: [
+      "TASK:",
+      "Summarize the weekly workout analytics data.",
+      "",
+      "CONSTRAINTS:",
+      "- Missing values are unknown.",
+      "- Missing effort values are not low effort.",
+      "- Do not prescribe a fixed training program.",
+      "- Keep the output concise.",
+      "",
+      "OUTPUT FORMAT:",
+      "- headline: string",
+      "- summary: string",
+      "- highlights: string[]",
+      "- concerns: string[]",
+      "- nextWeekFocus: string[]",
+      "- dataQualityNotes: string[]",
+      "",
+      "DATA:",
+      JSON.stringify({
+        rangeStart,
+        rangeEnd,
+        summaryInput,
+      }, null, 2),
+    ].join("\n"),
+  },
+];
+
+const generateWeeklySummary = async ({
+  rangeStart,
+  rangeEnd,
+  summaryInput,
+  provider = weeklySummaryMockProvider,
+}) => {
+  const fallback = buildRuleBasedFallbackSummary({
+    rangeStart,
+    rangeEnd,
+    summaryInput,
+  });
+  const promptMessages = buildWeeklySummaryPromptMessages({
+    rangeStart,
+    rangeEnd,
+    summaryInput,
+  });
+
+  try {
+    const providerResponse = await provider.generateWeeklySummary(promptMessages);
+    const validationResult = parseAndValidateWeeklySummaryResponse(
+      providerResponse,
+      fallback
+    );
+
+    if (validationResult.ok) {
+      return {
+        source: SUMMARY_SOURCE_AI,
+        summary: validationResult.value,
+        validationErrors: [],
+      };
+    }
+
+    return {
+      source: SUMMARY_SOURCE_FALLBACK,
+      summary: validationResult.value,
+      validationErrors: validationResult.errors,
+    };
+  } catch (error) {
+    return {
+      source: SUMMARY_SOURCE_FALLBACK,
+      summary: fallback,
+      validationErrors: ["Provider request failed."],
+    };
+  }
+};
+
+const getBearerToken = (req) => req.headers.authorization?.split(" ")[1];
+
+const handleGenerateWeeklySummary = async (req, res) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ error: "Authorization token missing" });
+  }
+
+  try {
+    const user = await verifyToken(token);
+    if (!user || !user.id) {
+      return res.status(401).json({ error: "Invalid token" });
+    }
+
+    const validation = validateWeeklySummaryRequest(req.body);
+    if (!validation.ok) {
+      return res.status(400).json({
+        error: "Invalid weekly summary request",
+        details: validation.errors,
+      });
+    }
+
+    const result = await generateWeeklySummary({
+      rangeStart: validation.value.rangeStart,
+      rangeEnd: validation.value.rangeEnd,
+      summaryInput: validation.value.summaryInput,
+      userId: user.id,
+    });
+
+    return res.status(200).json(result);
+  } catch (error) {
+    console.error("Weekly summary endpoint failed:", error.message);
+    return res.status(500).json({ error: "Failed to generate weekly summary" });
+  }
+};
+
+module.exports = {
+  SUMMARY_SOURCE_AI,
+  SUMMARY_SOURCE_FALLBACK,
+  buildRuleBasedFallbackSummary,
+  buildWeeklySummaryPromptMessages,
+  generateWeeklySummary,
+  handleGenerateWeeklySummary,
+};

--- a/backend/utils/__tests__/weeklySummaryRequestValidation.spec.js
+++ b/backend/utils/__tests__/weeklySummaryRequestValidation.spec.js
@@ -1,0 +1,117 @@
+/** @jest-environment node */
+
+const {
+  MAX_RANGE_DAYS,
+  validateWeeklySummaryRequest,
+} = require("../weeklySummaryRequestValidation");
+
+const validBody = {
+  rangeStart: "2026-06-01",
+  rangeEnd: "2026-06-07",
+  summaryInput: {
+    totalNotes: 3,
+    totalSets: 42,
+    dataQualityNotes: [],
+  },
+};
+
+describe("weeklySummaryRequestValidation", () => {
+  it("accepts a valid request", () => {
+    expect(validateWeeklySummaryRequest(validBody)).toEqual({
+      ok: true,
+      value: validBody,
+      errors: [],
+    });
+  });
+
+  it("rejects an invalid rangeStart", () => {
+    const result = validateWeeklySummaryRequest({
+      ...validBody,
+      rangeStart: "2026-02-30",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("rangeStart must be a valid YYYY-MM-DD date.");
+  });
+
+  it("rejects an invalid rangeEnd", () => {
+    const result = validateWeeklySummaryRequest({
+      ...validBody,
+      rangeEnd: "2026/06/07",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("rangeEnd must be a valid YYYY-MM-DD date.");
+  });
+
+  it("rejects a rangeEnd before rangeStart", () => {
+    const result = validateWeeklySummaryRequest({
+      ...validBody,
+      rangeStart: "2026-06-08",
+      rangeEnd: "2026-06-07",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("rangeEnd must be on or after rangeStart.");
+  });
+
+  it("rejects a range longer than the configured maximum", () => {
+    const result = validateWeeklySummaryRequest({
+      ...validBody,
+      rangeStart: "2026-01-01",
+      rangeEnd: "2026-12-31",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(`Date range must be ${MAX_RANGE_DAYS} days or less.`);
+  });
+
+  it("rejects a missing summaryInput", () => {
+    const result = validateWeeklySummaryRequest({
+      rangeStart: "2026-06-01",
+      rangeEnd: "2026-06-07",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("summaryInput must be an object.");
+  });
+
+  it("rejects a non-object summaryInput", () => {
+    const cases = [null, [], "summary"];
+
+    cases.forEach((summaryInput) => {
+      const result = validateWeeklySummaryRequest({
+        ...validBody,
+        summaryInput,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain("summaryInput must be an object.");
+    });
+  });
+
+  it("rejects raw note content fields", () => {
+    const result = validateWeeklySummaryRequest({
+      ...validBody,
+      summaryInput: {
+        totalNotes: 1,
+        nested: {
+          noteText: "private workout note",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("Raw note content field is not allowed: noteText.");
+  });
+
+  it("rejects a non-object request body", () => {
+    const result = validateWeeklySummaryRequest(null);
+
+    expect(result).toEqual({
+      ok: false,
+      value: null,
+      errors: ["Request body must be an object."],
+    });
+  });
+});

--- a/backend/utils/weeklySummaryMockProvider.js
+++ b/backend/utils/weeklySummaryMockProvider.js
@@ -1,0 +1,16 @@
+const weeklySummaryMockProvider = {
+  async generateWeeklySummary() {
+    return JSON.stringify({
+      headline: "Mock weekly summary",
+      summary: "This is a mocked weekly summary response.",
+      highlights: [],
+      concerns: [],
+      nextWeekFocus: [],
+      dataQualityNotes: [],
+    });
+  },
+};
+
+module.exports = {
+  weeklySummaryMockProvider,
+};

--- a/backend/utils/weeklySummaryRequestValidation.js
+++ b/backend/utils/weeklySummaryRequestValidation.js
@@ -1,0 +1,140 @@
+const MAX_RANGE_DAYS = 183;
+
+const RAW_NOTE_FIELD_NAMES = new Set([
+  "rawNoteText",
+  "rawNotes",
+  "notes",
+  "noteText",
+]);
+
+const isRecord = (value) => (
+  typeof value === "object" && value !== null && !Array.isArray(value)
+);
+
+const parseDateOnly = (value) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const date = new Date(timestamp);
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return {
+    value,
+    timestamp,
+  };
+};
+
+const findRawNoteField = (value) => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findRawNoteField(item);
+      if (found !== null) {
+        return found;
+      }
+    }
+
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  for (const key of Object.keys(value)) {
+    if (RAW_NOTE_FIELD_NAMES.has(key)) {
+      return key;
+    }
+
+    const found = findRawNoteField(value[key]);
+    if (found !== null) {
+      return found;
+    }
+  }
+
+  return null;
+};
+
+const validateWeeklySummaryRequest = (body) => {
+  const errors = [];
+
+  if (!isRecord(body)) {
+    return {
+      ok: false,
+      value: null,
+      errors: ["Request body must be an object."],
+    };
+  }
+
+  const rawNoteField = findRawNoteField(body);
+  if (rawNoteField !== null) {
+    errors.push(`Raw note content field is not allowed: ${rawNoteField}.`);
+  }
+
+  const rangeStart = parseDateOnly(body.rangeStart);
+  if (rangeStart === null) {
+    errors.push("rangeStart must be a valid YYYY-MM-DD date.");
+  }
+
+  const rangeEnd = parseDateOnly(body.rangeEnd);
+  if (rangeEnd === null) {
+    errors.push("rangeEnd must be a valid YYYY-MM-DD date.");
+  }
+
+  if (!isRecord(body.summaryInput)) {
+    errors.push("summaryInput must be an object.");
+  }
+
+  if (rangeStart !== null && rangeEnd !== null) {
+    if (rangeEnd.timestamp < rangeStart.timestamp) {
+      errors.push("rangeEnd must be on or after rangeStart.");
+    } else {
+      const rangeDays = Math.floor(
+        (rangeEnd.timestamp - rangeStart.timestamp) / 86400000
+      ) + 1;
+
+      if (rangeDays > MAX_RANGE_DAYS) {
+        errors.push(`Date range must be ${MAX_RANGE_DAYS} days or less.`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return {
+      ok: false,
+      value: null,
+      errors,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      rangeStart: rangeStart.value,
+      rangeEnd: rangeEnd.value,
+      summaryInput: body.summaryInput,
+    },
+    errors: [],
+  };
+};
+
+module.exports = {
+  MAX_RANGE_DAYS,
+  validateWeeklySummaryRequest,
+};

--- a/backend/utils/weeklySummaryResponseValidation.js
+++ b/backend/utils/weeklySummaryResponseValidation.js
@@ -1,0 +1,198 @@
+const HEADLINE_MAX_LENGTH = 120;
+const SUMMARY_MAX_LENGTH = 1000;
+const ARRAY_ITEM_MAX_LENGTH = 300;
+const ARRAY_MAX_ITEMS = 8;
+
+const ARRAY_FIELDS = [
+  "highlights",
+  "concerns",
+  "nextWeekFocus",
+  "dataQualityNotes",
+];
+
+const createEmptyWeeklySummaryResponse = () => ({
+  headline: "Weekly summary unavailable",
+  summary: "The weekly summary could not be validated.",
+  highlights: [],
+  concerns: [],
+  nextWeekFocus: [],
+  dataQualityNotes: ["Weekly summary response validation failed."],
+});
+
+const isRecord = (value) => (
+  typeof value === "object" && value !== null && !Array.isArray(value)
+);
+
+const truncate = (value, maxLength) => (
+  value.length > maxLength ? value.slice(0, maxLength) : value
+);
+
+const normalizeStringArray = (value) => {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return null;
+  }
+
+  return value
+    .slice(0, ARRAY_MAX_ITEMS)
+    .map((item) => truncate(item, ARRAY_ITEM_MAX_LENGTH));
+};
+
+const normalizeFallback = (fallback) => {
+  const empty = createEmptyWeeklySummaryResponse();
+
+  if (
+    !isRecord(fallback) ||
+    typeof fallback.headline !== "string" ||
+    typeof fallback.summary !== "string"
+  ) {
+    return empty;
+  }
+
+  const normalizedArrays = {};
+  for (const field of ARRAY_FIELDS) {
+    const normalized = normalizeStringArray(fallback[field]);
+    if (normalized === null) {
+      return empty;
+    }
+
+    normalizedArrays[field] = normalized;
+  }
+
+  return {
+    headline: truncate(fallback.headline, HEADLINE_MAX_LENGTH),
+    summary: truncate(fallback.summary, SUMMARY_MAX_LENGTH),
+    highlights: normalizedArrays.highlights,
+    concerns: normalizedArrays.concerns,
+    nextWeekFocus: normalizedArrays.nextWeekFocus,
+    dataQualityNotes: normalizedArrays.dataQualityNotes,
+  };
+};
+
+const validateStringField = (response, field, maxLength, errors) => {
+  if (!(field in response)) {
+    errors.push(`Missing required field: ${field}.`);
+    return null;
+  }
+
+  const value = response[field];
+  if (typeof value !== "string") {
+    errors.push(`Invalid field type: ${field} must be a string.`);
+    return null;
+  }
+
+  if (value.length > maxLength) {
+    errors.push(`String too long: ${field} must be at most ${maxLength} characters.`);
+    return null;
+  }
+
+  return value;
+};
+
+const validateArrayField = (response, field, errors) => {
+  if (!(field in response)) {
+    errors.push(`Missing required field: ${field}.`);
+    return null;
+  }
+
+  const value = response[field];
+  if (!Array.isArray(value)) {
+    errors.push(`Invalid field type: ${field} must be a string array.`);
+    return null;
+  }
+
+  if (value.length > ARRAY_MAX_ITEMS) {
+    errors.push(`Too many items: ${field} must contain at most ${ARRAY_MAX_ITEMS} items.`);
+    return null;
+  }
+
+  const invalidItemIndex = value.findIndex((item) => typeof item !== "string");
+  if (invalidItemIndex !== -1) {
+    errors.push(`Invalid array item: ${field}[${invalidItemIndex}] must be a string.`);
+    return null;
+  }
+
+  const tooLongIndex = value.findIndex((item) => item.length > ARRAY_ITEM_MAX_LENGTH);
+  if (tooLongIndex !== -1) {
+    errors.push(
+      `String too long: ${field}[${tooLongIndex}] must be at most ${ARRAY_ITEM_MAX_LENGTH} characters.`
+    );
+    return null;
+  }
+
+  return [...value];
+};
+
+const validateWeeklySummaryResponse = (response, fallback) => {
+  const fallbackValue = normalizeFallback(fallback);
+  const errors = [];
+
+  if (!isRecord(response)) {
+    return {
+      ok: false,
+      value: fallbackValue,
+      errors: ["Response must be an object."],
+    };
+  }
+
+  const headline = validateStringField(response, "headline", HEADLINE_MAX_LENGTH, errors);
+  const summary = validateStringField(response, "summary", SUMMARY_MAX_LENGTH, errors);
+  const highlights = validateArrayField(response, "highlights", errors);
+  const concerns = validateArrayField(response, "concerns", errors);
+  const nextWeekFocus = validateArrayField(response, "nextWeekFocus", errors);
+  const dataQualityNotes = validateArrayField(response, "dataQualityNotes", errors);
+
+  if (
+    errors.length > 0 ||
+    headline === null ||
+    summary === null ||
+    highlights === null ||
+    concerns === null ||
+    nextWeekFocus === null ||
+    dataQualityNotes === null
+  ) {
+    return {
+      ok: false,
+      value: fallbackValue,
+      errors,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      headline,
+      summary,
+      highlights,
+      concerns,
+      nextWeekFocus,
+      dataQualityNotes,
+    },
+    errors: [],
+  };
+};
+
+const parseAndValidateWeeklySummaryResponse = (responseText, fallback) => {
+  if (typeof responseText !== "string") {
+    return {
+      ok: false,
+      value: normalizeFallback(fallback),
+      errors: ["Response text must be a string."],
+    };
+  }
+
+  try {
+    return validateWeeklySummaryResponse(JSON.parse(responseText), fallback);
+  } catch (error) {
+    return {
+      ok: false,
+      value: normalizeFallback(fallback),
+      errors: ["JSON parse error."],
+    };
+  }
+};
+
+module.exports = {
+  createEmptyWeeklySummaryResponse,
+  parseAndValidateWeeklySummaryResponse,
+  validateWeeklySummaryResponse,
+};

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -66,6 +66,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Recharts and `react-is` are frontend dependencies only.
 - Backend auth utility tests under `backend/utils/__tests__` are included in `npm test` and CI.
 - Backend note exercises validation tests are included in `npm test` and CI.
+- Backend weekly summary endpoint skeleton tests are included in `npm test` and CI.
+- Backend weekly summary endpoint uses a mocked provider only and does not call an external AI API.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend `saveNote` defensively normalizes nested exercise intensity fields before persistence.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -77,7 +79,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add backend AI endpoint skeleton with mocked provider tests, provider adapter interface, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after backend endpoint and mocked provider tests.
+- Add provider adapter interface, frontend Generate AI summary button against the mocked endpoint, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after provider adapter and mocked endpoint tests.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.


### PR DESCRIPTION
## Summary

* Added backend weekly summary endpoint skeleton
* Added `/analytics/weekly-summary` route with the existing Bearer token verification pattern
* Added weekly summary request validation
* Added mocked weekly summary provider
* Added backend-local weekly summary response validation/fallback flow
* Returns `source: "ai"` for valid mocked provider responses
* Returns `source: "rule_based_fallback"` for invalid JSON, invalid shape, or provider errors
* Added service and validation tests
* Updated verification docs

## Verification

* `npm test` passed

  * 24 test suites passed
  * 266 tests passed
* `npm run build --prefix backend` passed

  * 22 files syntax checked
* `npm run lint --prefix frontend` passed
* `npm run build --prefix frontend` passed
* No new warnings were observed except the existing Google Fonts warning

## Package changes

* No package changes
* No package-lock changes
* No new dependencies

## Notes

* No external AI API integration
* No API keys or env changes
* No provider SDK added
* No DB changes
* No frontend UI changes
* Mock provider only
