### PR TITLE
Add weekly summary provider adapter

### DIFF
--- a/backend/services/__tests__/weeklySummaryService.spec.js
+++ b/backend/services/__tests__/weeklySummaryService.spec.js
@@ -80,6 +80,27 @@ describe("weeklySummaryService", () => {
   });
 
   describe("generateWeeklySummary", () => {
+    it("uses the default mock provider when provider is omitted", async () => {
+      const result = await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+      });
+
+      expect(result).toEqual({
+        source: SUMMARY_SOURCE_AI,
+        summary: {
+          headline: "Mock weekly summary",
+          summary: "This is a mocked weekly summary response.",
+          highlights: [],
+          concerns: [],
+          nextWeekFocus: [],
+          dataQualityNotes: [],
+        },
+        validationErrors: [],
+      });
+    });
+
     it("returns source ai when the mocked provider returns a valid response", async () => {
       const provider = {
         generateWeeklySummary: jest.fn().mockResolvedValue(createValidProviderResponse()),
@@ -101,6 +122,28 @@ describe("weeklySummaryService", () => {
           highlights: ["42 sets logged."],
           concerns: [],
           nextWeekFocus: ["Keep logging effort."],
+          dataQualityNotes: [],
+        },
+        validationErrors: [],
+      });
+    });
+
+    it("uses the default mock provider when an injected provider shape is invalid", async () => {
+      const result = await generateWeeklySummary({
+        rangeStart: "2026-06-01",
+        rangeEnd: "2026-06-07",
+        summaryInput: createSummaryInput(),
+        provider: { model: "not-used" },
+      });
+
+      expect(result).toEqual({
+        source: SUMMARY_SOURCE_AI,
+        summary: {
+          headline: "Mock weekly summary",
+          summary: "This is a mocked weekly summary response.",
+          highlights: [],
+          concerns: [],
+          nextWeekFocus: [],
           dataQualityNotes: [],
         },
         validationErrors: [],

--- a/backend/services/weeklySummaryService.js
+++ b/backend/services/weeklySummaryService.js
@@ -6,8 +6,9 @@ const {
   parseAndValidateWeeklySummaryResponse,
 } = require("../utils/weeklySummaryResponseValidation");
 const {
-  weeklySummaryMockProvider,
-} = require("../utils/weeklySummaryMockProvider");
+  getDefaultWeeklySummaryProvider,
+  isWeeklySummaryProvider,
+} = require("../utils/weeklySummaryProviderAdapter");
 
 const SUMMARY_SOURCE_AI = "ai";
 const SUMMARY_SOURCE_FALLBACK = "rule_based_fallback";
@@ -127,7 +128,7 @@ const generateWeeklySummary = async ({
   rangeStart,
   rangeEnd,
   summaryInput,
-  provider = weeklySummaryMockProvider,
+  provider,
 }) => {
   const fallback = buildRuleBasedFallbackSummary({
     rangeStart,
@@ -139,9 +140,12 @@ const generateWeeklySummary = async ({
     rangeEnd,
     summaryInput,
   });
+  const weeklySummaryProvider = isWeeklySummaryProvider(provider)
+    ? provider
+    : getDefaultWeeklySummaryProvider();
 
   try {
-    const providerResponse = await provider.generateWeeklySummary(promptMessages);
+    const providerResponse = await weeklySummaryProvider.generateWeeklySummary(promptMessages);
     const validationResult = parseAndValidateWeeklySummaryResponse(
       providerResponse,
       fallback

--- a/backend/utils/__tests__/weeklySummaryProviderAdapter.spec.js
+++ b/backend/utils/__tests__/weeklySummaryProviderAdapter.spec.js
@@ -1,0 +1,87 @@
+/** @jest-environment node */
+
+const {
+  createMockWeeklySummaryProvider,
+  getDefaultWeeklySummaryProvider,
+  isWeeklySummaryProvider,
+} = require("../weeklySummaryProviderAdapter");
+
+describe("weeklySummaryProviderAdapter", () => {
+  it("default mock provider returns a valid JSON string", async () => {
+    const provider = getDefaultWeeklySummaryProvider();
+    const responseText = await provider.generateWeeklySummary([]);
+
+    expect(typeof responseText).toBe("string");
+    expect(JSON.parse(responseText)).toEqual({
+      headline: "Mock weekly summary",
+      summary: "This is a mocked weekly summary response.",
+      highlights: [],
+      concerns: [],
+      nextWeekFocus: [],
+      dataQualityNotes: [],
+    });
+  });
+
+  it("mock provider can return custom responseText", async () => {
+    const responseText = JSON.stringify({
+      headline: "Custom",
+      summary: "Custom response.",
+      highlights: ["A"],
+      concerns: [],
+      nextWeekFocus: [],
+      dataQualityNotes: [],
+    });
+    const provider = createMockWeeklySummaryProvider({ responseText });
+
+    await expect(provider.generateWeeklySummary([])).resolves.toBe(responseText);
+  });
+
+  it("mock provider can throw when configured", async () => {
+    const provider = createMockWeeklySummaryProvider({ shouldThrow: true });
+
+    await expect(provider.generateWeeklySummary([])).rejects.toThrow(
+      "Mock weekly summary provider failed."
+    );
+  });
+
+  it("identifies valid weekly summary providers", () => {
+    expect(isWeeklySummaryProvider({
+      generateWeeklySummary: async () => "{}",
+    })).toBe(true);
+  });
+
+  it("rejects invalid provider shapes", () => {
+    expect(isWeeklySummaryProvider(null)).toBe(false);
+    expect(isWeeklySummaryProvider(undefined)).toBe(false);
+    expect(isWeeklySummaryProvider({})).toBe(false);
+    expect(isWeeklySummaryProvider({ generateWeeklySummary: "not-a-function" })).toBe(false);
+  });
+
+  it("does not require provider-specific fields", () => {
+    const provider = createMockWeeklySummaryProvider();
+
+    expect(provider).toHaveProperty("generateWeeklySummary");
+    expect(provider).not.toHaveProperty("model");
+    expect(provider).not.toHaveProperty("temperature");
+    expect(provider).not.toHaveProperty("apiKey");
+  });
+
+  it("does not mutate promptMessages", async () => {
+    const provider = createMockWeeklySummaryProvider();
+    const promptMessages = [
+      {
+        role: "system",
+        content: "Use only aggregate data.",
+      },
+      {
+        role: "user",
+        content: "DATA: {}",
+      },
+    ];
+    const original = JSON.parse(JSON.stringify(promptMessages));
+
+    await provider.generateWeeklySummary(promptMessages);
+
+    expect(promptMessages).toEqual(original);
+  });
+});

--- a/backend/utils/weeklySummaryMockProvider.js
+++ b/backend/utils/weeklySummaryMockProvider.js
@@ -1,16 +1,10 @@
-const weeklySummaryMockProvider = {
-  async generateWeeklySummary() {
-    return JSON.stringify({
-      headline: "Mock weekly summary",
-      summary: "This is a mocked weekly summary response.",
-      highlights: [],
-      concerns: [],
-      nextWeekFocus: [],
-      dataQualityNotes: [],
-    });
-  },
-};
+const {
+  createMockWeeklySummaryProvider,
+} = require("./weeklySummaryProviderAdapter");
+
+const weeklySummaryMockProvider = createMockWeeklySummaryProvider();
 
 module.exports = {
+  createMockWeeklySummaryProvider,
   weeklySummaryMockProvider,
 };

--- a/backend/utils/weeklySummaryProviderAdapter.js
+++ b/backend/utils/weeklySummaryProviderAdapter.js
@@ -1,0 +1,33 @@
+const DEFAULT_MOCK_WEEKLY_SUMMARY_RESPONSE = {
+  headline: "Mock weekly summary",
+  summary: "This is a mocked weekly summary response.",
+  highlights: [],
+  concerns: [],
+  nextWeekFocus: [],
+  dataQualityNotes: [],
+};
+
+const createMockWeeklySummaryProvider = ({
+  responseText,
+  shouldThrow = false,
+} = {}) => ({
+  async generateWeeklySummary() {
+    if (shouldThrow) {
+      throw new Error("Mock weekly summary provider failed.");
+    }
+
+    return responseText ?? JSON.stringify(DEFAULT_MOCK_WEEKLY_SUMMARY_RESPONSE);
+  },
+});
+
+const isWeeklySummaryProvider = (provider) => (
+  Boolean(provider) && typeof provider.generateWeeklySummary === "function"
+);
+
+const getDefaultWeeklySummaryProvider = () => createMockWeeklySummaryProvider();
+
+module.exports = {
+  createMockWeeklySummaryProvider,
+  getDefaultWeeklySummaryProvider,
+  isWeeklySummaryProvider,
+};

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -68,6 +68,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Backend note exercises validation tests are included in `npm test` and CI.
 - Backend weekly summary endpoint skeleton tests are included in `npm test` and CI.
 - Backend weekly summary endpoint uses a mocked provider only and does not call an external AI API.
+- Backend weekly summary provider adapter tests are included in `npm test` and CI.
+- Backend weekly summary provider adapter remains mocked and does not call an external AI API.
 - Backend note service tests under `backend/services/__tests__` are included in `npm test` and CI.
 - Backend `saveNote` defensively normalizes nested exercise intensity fields before persistence.
 - Backend auth service validation and refresh tests under `backend/services/__tests__` are included in `npm test` and CI.
@@ -79,7 +81,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add provider adapter interface, frontend Generate AI summary button against the mocked endpoint, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after provider adapter and mocked endpoint tests.
+- Add frontend Generate AI summary button against the mocked endpoint, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after the mocked endpoint and frontend flow are stable.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.


### PR DESCRIPTION
## Summary

* Added backend weekly summary provider adapter boundary
* Added `createMockWeeklySummaryProvider`
* Added `isWeeklySummaryProvider`
* Added `getDefaultWeeklySummaryProvider`
* Converted existing mock provider to use the adapter factory
* Updated weekly summary service to validate provider shape before use
* Falls back to the default mock provider for invalid provider shapes
* Keeps provider errors on the existing `rule_based_fallback` path
* Added provider adapter and service tests
* Updated verification docs

## Verification

* `npm test` passed

  * 25 test suites passed
  * 275 tests passed
* `npm run build --prefix backend` passed

  * 24 files syntax checked
* `npm run lint --prefix frontend` passed
* `npm run build --prefix frontend` passed
* No new warnings were observed except the existing Google Fonts warning

## Package changes

* No package changes
* No package-lock changes
* No new dependencies

## Notes

* No external AI API integration
* No API keys or env changes
* No provider SDK added
* No network calls
* No DB changes
* No frontend UI changes
* Mock provider only
