### PR TITLE
Add frontend weekly summary generation flow

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -55,6 +55,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
 - The `/analytics` page scaffold reuses the authenticated notes range API and is covered by frontend lint and build checks.
+- Frontend weekly summary API helper tests are included in `npm test` and CI.
+- Analytics can request a mocked backend weekly summary response without calling an external AI API.
 - Analytics uses Recharts for the BIG3 estimated 1RM line chart; BIG3 cards remain as accessible exact-value fallback content.
 - Analytics uses Recharts for the weekly muscle-group chart with `totalSets` / `totalVolumeLoad` metric toggle; the muscle-group table remains as exact-value fallback content.
 - Analytics includes an exercise trend selector using existing normalized set metrics and canonical exercise groups when metadata matches.
@@ -81,7 +83,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add frontend Generate AI summary button against the mocked endpoint, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and external AI integration only after the mocked endpoint and frontend flow are stable.
+- Add external AI integration only after the mocked frontend/backend flow is stable, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, and optional weekly summary persistence/cache design.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/api/__tests__/weeklySummaryApi.spec.ts
+++ b/frontend/features/analytics/api/__tests__/weeklySummaryApi.spec.ts
@@ -1,0 +1,70 @@
+/// <reference types="jest" />
+
+const apiRequestWithAuth = jest.fn();
+
+jest.mock("../../../../lib/apiClient", () => ({
+  apiRequestWithAuth,
+}));
+
+const { generateWeeklySummaryAPI } = require("../weeklySummaryApi") as typeof import("../weeklySummaryApi");
+
+const createRequest = () => ({
+  rangeStart: "2026-06-01",
+  rangeEnd: "2026-06-07",
+  summaryInput: {
+    rangeStart: "2026-06-01",
+    rangeEnd: "2026-06-07",
+    totalNotes: 3,
+    totalSets: 42,
+    big3: [],
+    muscleGroups: [],
+    effort: {
+      totalSetCount: 42,
+      effortLoggedSetCount: 12,
+      rpeCount: 10,
+      averageRpe: 8.1,
+      rirCount: 8,
+      averageRir: 1.5,
+      failureCount: 2,
+    },
+    dataQualityNotes: [],
+  },
+});
+
+describe("weeklySummaryApi", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("posts the weekly summary request to the mocked backend endpoint", async () => {
+    const request = createRequest();
+    const response = {
+      source: "ai",
+      summary: {
+        headline: "Mock weekly summary",
+        summary: "This is a mocked weekly summary response.",
+        highlights: [],
+        concerns: [],
+        nextWeekFocus: [],
+        dataQualityNotes: [],
+      },
+      validationErrors: [],
+    };
+    apiRequestWithAuth.mockResolvedValue(response);
+
+    await expect(generateWeeklySummaryAPI(request)).resolves.toEqual(response);
+
+    expect(apiRequestWithAuth).toHaveBeenCalledWith(
+      "/analytics/weekly-summary",
+      "post",
+      request
+    );
+  });
+
+  it("rejects when the authenticated request fails", async () => {
+    const error = new Error("Request failed");
+    apiRequestWithAuth.mockRejectedValue(error);
+
+    await expect(generateWeeklySummaryAPI(createRequest())).rejects.toBe(error);
+  });
+});

--- a/frontend/features/analytics/api/weeklySummaryApi.ts
+++ b/frontend/features/analytics/api/weeklySummaryApi.ts
@@ -1,0 +1,27 @@
+import { apiRequestWithAuth } from "../../../lib/apiClient";
+import type { WeeklySummaryInput } from "../../../../shared/utils/weeklySummaryInput";
+import type { RuleBasedWeeklySummary } from "../../../../shared/utils/ruleBasedWeeklySummary";
+
+export type WeeklySummaryEndpointSource = "ai" | "rule_based_fallback";
+
+export type GenerateWeeklySummaryRequest = {
+  rangeStart: string;
+  rangeEnd: string;
+  summaryInput: WeeklySummaryInput;
+};
+
+export type GenerateWeeklySummaryResponse = {
+  source: WeeklySummaryEndpointSource;
+  summary: RuleBasedWeeklySummary;
+  validationErrors: string[];
+};
+
+export const generateWeeklySummaryAPI = async (
+  request: GenerateWeeklySummaryRequest
+): Promise<GenerateWeeklySummaryResponse> => (
+  apiRequestWithAuth<GenerateWeeklySummaryResponse, GenerateWeeklySummaryRequest>(
+    "/analytics/weekly-summary",
+    "post",
+    request
+  )
+);

--- a/frontend/features/analytics/components/WeeklySummaryPreviewSection.tsx
+++ b/frontend/features/analytics/components/WeeklySummaryPreviewSection.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
   Badge,
   Box,
+  Button,
   Flex,
   Heading,
   List,
@@ -13,11 +17,19 @@ import {
 import type {
   RuleBasedWeeklySummary,
 } from "../../../../shared/utils/ruleBasedWeeklySummary";
+import type {
+  GenerateWeeklySummaryResponse,
+} from "../api/weeklySummaryApi";
 
 type WeeklySummaryPreviewSectionProps = {
   summary: RuleBasedWeeklySummary;
   rangeStart: string;
   rangeEnd: string;
+  generatedResponse?: GenerateWeeklySummaryResponse | null;
+  generationError?: string | null;
+  isGenerating?: boolean;
+  canGenerate?: boolean;
+  onGenerate?: () => void;
 };
 
 type SummaryListProps = {
@@ -51,10 +63,74 @@ const SummaryList: React.FC<SummaryListProps> = ({
   </Box>
 );
 
+const getGeneratedLabel = (source: GenerateWeeklySummaryResponse["source"]) => (
+  source === "ai" ? "Mocked endpoint response" : "Fallback summary"
+);
+
+const SummaryCard: React.FC<{
+  summary: RuleBasedWeeklySummary;
+  badgeLabel: string;
+  badgeColorScheme?: string;
+}> = ({
+  summary,
+  badgeLabel,
+  badgeColorScheme = "gray",
+}) => (
+  <Box bg="gray.50" borderRadius="6px" p={4}>
+    <Flex
+      align={{ base: "flex-start", sm: "center" }}
+      justify="space-between"
+      gap={3}
+      direction={{ base: "column", sm: "row" }}
+      mb={3}
+    >
+      <Box>
+        <Text fontWeight="semibold" color="gray.800">
+          {summary.headline}
+        </Text>
+      </Box>
+      <Badge colorScheme={badgeColorScheme} alignSelf={{ base: "flex-start", sm: "center" }}>
+        {badgeLabel}
+      </Badge>
+    </Flex>
+    <Text fontSize="sm" color="gray.700">
+      {summary.summary}
+    </Text>
+
+    <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={4}>
+      <SummaryList
+        title="Highlights"
+        items={summary.highlights}
+        emptyText="No highlights yet."
+      />
+      <SummaryList
+        title="Concerns"
+        items={summary.concerns}
+        emptyText="No concerns from the available data."
+      />
+      <SummaryList
+        title="Next Week Focus"
+        items={summary.nextWeekFocus}
+        emptyText="No focus items yet."
+      />
+      <SummaryList
+        title="Data Quality"
+        items={summary.dataQualityNotes}
+        emptyText="No data quality notes."
+      />
+    </SimpleGrid>
+  </Box>
+);
+
 const WeeklySummaryPreviewSection: React.FC<WeeklySummaryPreviewSectionProps> = ({
   summary,
   rangeStart,
   rangeEnd,
+  generatedResponse = null,
+  generationError = null,
+  isGenerating = false,
+  canGenerate = true,
+  onGenerate,
 }) => (
   <Box
     as="section"
@@ -80,42 +156,53 @@ const WeeklySummaryPreviewSection: React.FC<WeeklySummaryPreviewSectionProps> = 
             {rangeStart} to {rangeEnd}
           </Text>
         </Box>
-        <Badge colorScheme="gray" alignSelf={{ base: "flex-start", sm: "center" }}>
-          Rule-based preview
-        </Badge>
+        <Button
+          colorScheme="teal"
+          size="sm"
+          onClick={onGenerate}
+          isLoading={isGenerating}
+          loadingText="Generating"
+          isDisabled={!canGenerate || isGenerating || !onGenerate}
+          alignSelf={{ base: "stretch", sm: "center" }}
+          w={{ base: "100%", sm: "auto" }}
+        >
+          Generate AI summary
+        </Button>
       </Flex>
 
-      <Box bg="gray.50" borderRadius="6px" p={4}>
-        <Text fontWeight="semibold" color="gray.800">
-          {summary.headline}
-        </Text>
-        <Text mt={2} fontSize="sm" color="gray.700">
-          {summary.summary}
-        </Text>
-      </Box>
+      <Text fontSize="sm" color="gray.600">
+        Uses the mocked backend endpoint for now. The local rule-based preview remains visible.
+      </Text>
 
-      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-        <SummaryList
-          title="Highlights"
-          items={summary.highlights}
-          emptyText="No highlights yet."
-        />
-        <SummaryList
-          title="Concerns"
-          items={summary.concerns}
-          emptyText="No concerns from the available data."
-        />
-        <SummaryList
-          title="Next Week Focus"
-          items={summary.nextWeekFocus}
-          emptyText="No focus items yet."
-        />
-        <SummaryList
-          title="Data Quality"
-          items={summary.dataQualityNotes}
-          emptyText="No data quality notes."
-        />
-      </SimpleGrid>
+      {generationError && (
+        <Alert status="error" variant="left-accent">
+          <AlertIcon />
+          <AlertDescription>{generationError}</AlertDescription>
+        </Alert>
+      )}
+
+      <SummaryCard summary={summary} badgeLabel="Rule-based preview" />
+
+      {generatedResponse && (
+        <Box>
+          <SummaryCard
+            summary={generatedResponse.summary}
+            badgeLabel={getGeneratedLabel(generatedResponse.source)}
+            badgeColorScheme={generatedResponse.source === "ai" ? "teal" : "orange"}
+          />
+          {generatedResponse.validationErrors.length > 0 && (
+            <Text mt={2} fontSize="xs" color="gray.500">
+              Validation notes: {generatedResponse.validationErrors.slice(0, 2).join(" ")}
+            </Text>
+          )}
+        </Box>
+      )}
+
+      {!generatedResponse && (
+        <Text fontSize="xs" color="gray.500">
+          Generated endpoint response will appear here after the request completes.
+        </Text>
+      )}
     </Stack>
   </Box>
 );

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -43,6 +43,10 @@ import {
 } from "../../../../shared/utils/trainingMetrics";
 import { buildWeeklySummaryInput } from "../../../../shared/utils/weeklySummaryInput";
 import { fetchNotesInRangeAPI } from "../../notes/api";
+import {
+  generateWeeklySummaryAPI,
+  type GenerateWeeklySummaryResponse,
+} from "../api/weeklySummaryApi";
 import AnalyticsRangeFilter, {
   type AnalyticsRange,
 } from "../components/AnalyticsRangeFilter";
@@ -92,9 +96,14 @@ const getDateRange = (range: AnalyticsRange): { start: string; end: string } => 
 const AnalyticsPage: React.FC = () => {
   const router = useRouter();
   const requestIdRef = useRef(0);
+  const weeklySummaryRequestIdRef = useRef(0);
   const [range, setRange] = useState<AnalyticsRange>("12w");
   const [reloadKey, setReloadKey] = useState(0);
   const [status, setStatus] = useState<LoadStatus>("loading");
+  const [generatedWeeklySummary, setGeneratedWeeklySummary] =
+    useState<GenerateWeeklySummaryResponse | null>(null);
+  const [weeklySummaryError, setWeeklySummaryError] = useState<string | null>(null);
+  const [isGeneratingWeeklySummary, setIsGeneratingWeeklySummary] = useState(false);
   const [noteCount, setNoteCount] = useState(0);
   const [normalizedSetCount, setNormalizedSetCount] = useState(0);
   const [big3Summaries, setBig3Summaries] = useState<Big3TrendSummary[]>(() =>
@@ -138,6 +147,13 @@ const AnalyticsPage: React.FC = () => {
   );
 
   useEffect(() => {
+    weeklySummaryRequestIdRef.current += 1;
+    setGeneratedWeeklySummary(null);
+    setWeeklySummaryError(null);
+    setIsGeneratingWeeklySummary(false);
+  }, [dateRange.end, dateRange.start, reloadKey]);
+
+  useEffect(() => {
     if (!getToken()) {
       router.replace(URLS.LOGIN_PAGE);
       return;
@@ -177,6 +193,39 @@ const AnalyticsPage: React.FC = () => {
       }
     };
   }, [dateRange.end, dateRange.start, reloadKey, router]);
+
+  const handleGenerateWeeklySummary = async () => {
+    if (status !== "success") {
+      return;
+    }
+
+    const requestId = ++weeklySummaryRequestIdRef.current;
+    setIsGeneratingWeeklySummary(true);
+    setWeeklySummaryError(null);
+    setGeneratedWeeklySummary(null);
+
+    try {
+      const response = await generateWeeklySummaryAPI({
+        rangeStart: dateRange.start,
+        rangeEnd: dateRange.end,
+        summaryInput: weeklySummaryInput,
+      });
+
+      if (requestId !== weeklySummaryRequestIdRef.current) {
+        return;
+      }
+
+      setGeneratedWeeklySummary(response);
+    } catch {
+      if (requestId === weeklySummaryRequestIdRef.current) {
+        setWeeklySummaryError("Mocked weekly summary request failed.");
+      }
+    } finally {
+      if (requestId === weeklySummaryRequestIdRef.current) {
+        setIsGeneratingWeeklySummary(false);
+      }
+    }
+  };
 
   const hasExerciseData = setsWithMetrics.some((set) => set.exerciseName.trim() !== "");
   const hasEffortData = effortSummary.effortLoggedSetCount > 0;
@@ -244,6 +293,11 @@ const AnalyticsPage: React.FC = () => {
               summary={weeklySummary}
               rangeStart={dateRange.start}
               rangeEnd={dateRange.end}
+              generatedResponse={generatedWeeklySummary}
+              generationError={weeklySummaryError}
+              isGenerating={isGeneratingWeeklySummary}
+              canGenerate={status === "success"}
+              onGenerate={handleGenerateWeeklySummary}
             />
           </Box>
         )}


### PR DESCRIPTION
## Summary
- Added frontend weekly summary API helper
- Added `generateWeeklySummaryAPI`
- Calls the mocked backend `/analytics/weekly-summary` endpoint
- Added `Generate AI summary` button to the weekly summary card
- Keeps the existing rule-based preview visible
- Displays mocked endpoint responses separately from fallback summaries
- Added loading, error, and range-change clearing behavior
- Added frontend API helper tests
- Updated verification docs

## Verification
- `npm test` passed
  - 26 test suites passed
  - 277 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No external AI API integration
- No API keys or env changes
- No provider SDK added
- No DB changes
- No backend provider changes
- Mocked backend endpoint only
- Browser visual confirmation was not completed because an authenticated browser session was required