### PR TITLE
Add growth signals helper

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -51,6 +51,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Weekly summary prompt builder creates provider-neutral prompt payloads without calling an external AI API.
 - Shared weekly summary response validation tests are included in `npm test` and CI.
 - Weekly summary response validation safely validates structured weekly summary responses before future AI rendering.
+- Shared Growth Signals helper tests are included in `npm test` and CI.
+- Growth Signals derive deterministic analytics signals without calling an external AI API.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
@@ -83,7 +85,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add Growth Signals pure helper and tests, Analytics Growth Signals card, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, optional weekly summary persistence/cache design, and external AI integration only after core analytics signals and the mocked frontend/backend flow are stable.
+- Add Analytics Growth Signals card, Growth Signals integration into Weekly Summary input if useful, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, optional weekly summary persistence/cache design, and external AI integration only after core analytics signals and the mocked frontend/backend flow are stable.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/shared/utils/__tests__/growthSignals.spec.ts
+++ b/shared/utils/__tests__/growthSignals.spec.ts
@@ -1,0 +1,420 @@
+import {
+  buildGrowthSignals,
+  type BuildGrowthSignalsInput,
+  type GrowthSignal,
+} from "../growthSignals";
+
+const buildInput = (overrides: Partial<BuildGrowthSignalsInput> = {}): BuildGrowthSignalsInput => ({
+  rangeStart: "2026-06-01",
+  rangeEnd: "2026-06-07",
+  totalNotes: 3,
+  totalSets: 42,
+  big3: [
+    {
+      lift: "squat",
+      latestEstimatedOneRepMax: 152.5,
+      maxEstimatedOneRepMax: 155,
+      trendPointCount: 2,
+    },
+    {
+      lift: "bench",
+      latestEstimatedOneRepMax: 102.5,
+      maxEstimatedOneRepMax: 105,
+      trendPointCount: 3,
+    },
+    {
+      lift: "deadlift",
+      latestEstimatedOneRepMax: 180,
+      maxEstimatedOneRepMax: 185,
+      trendPointCount: 1,
+    },
+  ],
+  muscleGroups: [
+    {
+      muscle: "chest",
+      totalSets: 12,
+      totalVolumeLoad: 2400,
+    },
+    {
+      muscle: "back",
+      totalSets: 10,
+      totalVolumeLoad: 2200,
+    },
+  ],
+  effort: {
+    totalSetCount: 42,
+    effortLoggedSetCount: 24,
+    rpeCount: 20,
+    averageRpe: 8.1,
+    rirCount: 16,
+    averageRir: 1.5,
+    failureCount: 3,
+  },
+  dataQualityNotes: [],
+  ...overrides,
+});
+
+const getSignal = (signals: GrowthSignal[], id: string): GrowthSignal => {
+  const signal = signals.find((item) => item.id === id);
+  if (!signal) {
+    throw new Error(`Missing signal: ${id}`);
+  }
+
+  return signal;
+};
+
+const expectNoUnsafeNumbers = (value: unknown) => {
+  const serialized = JSON.stringify(value);
+
+  expect(serialized).not.toContain("NaN");
+  expect(serialized).not.toContain("Infinity");
+};
+
+describe("growthSignals", () => {
+  describe("buildGrowthSignals", () => {
+    it("returns 5 ordered signals from full data", () => {
+      const summary = buildGrowthSignals(buildInput());
+
+      expect(summary.rangeStart).toBe("2026-06-01");
+      expect(summary.rangeEnd).toBe("2026-06-07");
+      expect(summary.signals.map((signal) => signal.id)).toEqual([
+        "strength",
+        "volume",
+        "consistency",
+        "effort",
+        "exercise_progress",
+      ]);
+      expect(summary.signals).toHaveLength(5);
+    });
+
+    it("marks consistency unknown and adds notes when no notes or sets are present", () => {
+      const summary = buildGrowthSignals(buildInput({
+        totalNotes: 0,
+        totalSets: 0,
+      }));
+      const consistency = getSignal(summary.signals, "consistency");
+
+      expect(consistency.status).toBe("unknown");
+      expect(summary.dataQualityNotes).toEqual(expect.arrayContaining([
+        "No workout notes found in this range.",
+        "No normalized sets found in this range.",
+      ]));
+    });
+
+    it("marks strength unknown when there is no BIG3 data", () => {
+      const summary = buildGrowthSignals(buildInput({ big3: [] }));
+      const strength = getSignal(summary.signals, "strength");
+
+      expect(strength.status).toBe("unknown");
+      expect(strength.detail).toContain("No BIG3 estimated 1RM trend points");
+      expect(summary.dataQualityNotes).toContain("No BIG3 trend data found in this range.");
+    });
+
+    it("marks strength neutral when BIG3 data exists without previous comparison", () => {
+      const summary = buildGrowthSignals(buildInput());
+      const strength = getSignal(summary.signals, "strength");
+
+      expect(strength.status).toBe("neutral");
+      expect(strength.evidence).toEqual([
+        "BIG3 trend points: 6.",
+        "Deadlift max estimated 1RM: 185.",
+        "Deadlift latest estimated 1RM: 180.",
+      ]);
+      expect(strength.detail).toContain("previous range comparison is not connected yet");
+    });
+
+    it("marks volume unknown when there is no muscle group data", () => {
+      const summary = buildGrowthSignals(buildInput({ muscleGroups: [] }));
+      const volume = getSignal(summary.signals, "volume");
+
+      expect(volume.status).toBe("unknown");
+      expect(volume.detail).toContain("No muscle group volume data");
+      expect(summary.dataQualityNotes).toContain(
+        "No muscle group volume data found in this range."
+      );
+    });
+
+    it("marks volume neutral when muscle group data exists", () => {
+      const summary = buildGrowthSignals(buildInput());
+      const volume = getSignal(summary.signals, "volume");
+
+      expect(volume.status).toBe("neutral");
+      expect(volume.evidence).toEqual([
+        "chest: 12 sets.",
+        "chest volume load: 2,400.",
+        "back: 10 sets.",
+      ]);
+    });
+
+    it("marks volume watch when top muscle group has at least 3x second muscle group sets", () => {
+      const summary = buildGrowthSignals(buildInput({
+        muscleGroups: [
+          {
+            muscle: "chest",
+            totalSets: 18,
+            totalVolumeLoad: 3600,
+          },
+          {
+            muscle: "back",
+            totalSets: 6,
+            totalVolumeLoad: 1200,
+          },
+        ],
+      }));
+      const volume = getSignal(summary.signals, "volume");
+
+      expect(volume.status).toBe("watch");
+      expect(volume.headline).toBe("Volume may be concentrated");
+      expect(volume.nextFocus).toContain("matches your plan");
+    });
+
+    it("marks consistency watch for low notes", () => {
+      const summary = buildGrowthSignals(buildInput({
+        totalNotes: 1,
+        totalSets: 12,
+      }));
+      const consistency = getSignal(summary.signals, "consistency");
+
+      expect(consistency.status).toBe("watch");
+      expect(consistency.evidence).toEqual([
+        "Workout notes: 1.",
+        "Normalized sets: 12.",
+      ]);
+    });
+
+    it("marks consistency watch for low sets", () => {
+      const summary = buildGrowthSignals(buildInput({
+        totalNotes: 3,
+        totalSets: 4,
+      }));
+
+      expect(getSignal(summary.signals, "consistency").status).toBe("watch");
+    });
+
+    it("marks consistency neutral when notes and sets are sufficient", () => {
+      const summary = buildGrowthSignals(buildInput());
+      const consistency = getSignal(summary.signals, "consistency");
+
+      expect(consistency.status).toBe("neutral");
+      expect(consistency.detail).toContain("enough logged notes and sets");
+    });
+
+    it("marks effort unknown when no effort data is logged", () => {
+      const summary = buildGrowthSignals(buildInput({
+        effort: {
+          totalSetCount: 12,
+          effortLoggedSetCount: 0,
+          rpeCount: 0,
+          averageRpe: null,
+          rirCount: 0,
+          averageRir: null,
+          failureCount: 0,
+        },
+      }));
+      const effort = getSignal(summary.signals, "effort");
+
+      expect(effort.status).toBe("unknown");
+      expect(effort.detail).toContain("No RPE, RIR, or failure data");
+      expect(summary.dataQualityNotes).toContain("No effort data logged in this range.");
+    });
+
+    it("marks effort watch when effort coverage is below 25%", () => {
+      const summary = buildGrowthSignals(buildInput({
+        effort: {
+          totalSetCount: 20,
+          effortLoggedSetCount: 4,
+          rpeCount: 2,
+          averageRpe: 8,
+          rirCount: 2,
+          averageRir: 2,
+          failureCount: 0,
+        },
+      }));
+      const effort = getSignal(summary.signals, "effort");
+
+      expect(effort.status).toBe("watch");
+      expect(effort.headline).toBe("Effort data is sparse");
+      expect(effort.evidence).toContain("Effort coverage: 4 / 20 sets (20%).");
+    });
+
+    it("marks effort watch when failure ratio is 20% or higher", () => {
+      const summary = buildGrowthSignals(buildInput({
+        effort: {
+          totalSetCount: 20,
+          effortLoggedSetCount: 18,
+          rpeCount: 12,
+          averageRpe: 8.5,
+          rirCount: 10,
+          averageRir: 1,
+          failureCount: 4,
+        },
+      }));
+      const effort = getSignal(summary.signals, "effort");
+
+      expect(effort.status).toBe("watch");
+      expect(effort.headline).toBe("Failure sets are worth watching");
+      expect(effort.detail).toContain("At least 20% of sets");
+    });
+
+    it("includes average RPE/RIR evidence only when finite", () => {
+      const summary = buildGrowthSignals(buildInput({
+        effort: {
+          totalSetCount: 20,
+          effortLoggedSetCount: 10,
+          rpeCount: 5,
+          averageRpe: Number.NaN,
+          rirCount: 5,
+          averageRir: Number.POSITIVE_INFINITY,
+          failureCount: 1,
+        },
+      }));
+      const effort = getSignal(summary.signals, "effort");
+
+      expect(effort.evidence).toEqual([
+        "Effort coverage: 10 / 20 sets (50%).",
+        "Failure sets: 1.",
+      ]);
+      expectNoUnsafeNumbers(summary);
+    });
+
+    it("treats missing effort values as unknown, not low effort", () => {
+      const summary = buildGrowthSignals(buildInput({
+        effort: {
+          totalSetCount: 20,
+          effortLoggedSetCount: 0,
+          rpeCount: 0,
+          averageRpe: null,
+          rirCount: 0,
+          averageRir: null,
+          failureCount: 0,
+        },
+      }));
+      const effort = getSignal(summary.signals, "effort");
+
+      expect(effort.status).toBe("unknown");
+      expect(JSON.stringify(effort)).not.toContain("low effort");
+    });
+
+    it("keeps exercise_progress unknown initially", () => {
+      const summary = buildGrowthSignals(buildInput());
+      const exerciseProgress = getSignal(summary.signals, "exercise_progress");
+
+      expect(exerciseProgress.status).toBe("unknown");
+      expect(exerciseProgress.detail).toContain("Selected exercise trend data is not connected");
+      expect(exerciseProgress.nextFocus).toContain("exercise trend selector");
+    });
+
+    it("generates and dedupes data quality notes", () => {
+      const summary = buildGrowthSignals(buildInput({
+        totalNotes: 0,
+        totalSets: 0,
+        big3: [],
+        muscleGroups: [],
+        effort: {
+          totalSetCount: 0,
+          effortLoggedSetCount: 0,
+          rpeCount: 0,
+          averageRpe: null,
+          rirCount: 0,
+          averageRir: null,
+          failureCount: 0,
+        },
+        dataQualityNotes: [
+          "No workout notes found in this range.",
+          "No workout notes found in this range.",
+          "Custom note.",
+          123 as unknown as string,
+        ],
+      }));
+
+      expect(summary.dataQualityNotes).toEqual([
+        "No workout notes found in this range.",
+        "Custom note.",
+        "No normalized sets found in this range.",
+        "No BIG3 trend data found in this range.",
+        "No muscle group volume data found in this range.",
+        "No effort data logged in this range.",
+      ]);
+    });
+
+    it("ignores invalid numeric values", () => {
+      const summary = buildGrowthSignals(buildInput({
+        totalNotes: Number.NaN,
+        totalSets: Number.POSITIVE_INFINITY,
+        big3: [
+          {
+            lift: "bench",
+            latestEstimatedOneRepMax: Number.NaN,
+            maxEstimatedOneRepMax: Number.POSITIVE_INFINITY,
+            trendPointCount: Number.NaN,
+          },
+        ],
+        muscleGroups: [
+          {
+            muscle: "chest",
+            totalSets: Number.NaN,
+            totalVolumeLoad: Number.POSITIVE_INFINITY,
+          },
+        ],
+        effort: {
+          totalSetCount: Number.NaN,
+          effortLoggedSetCount: Number.POSITIVE_INFINITY,
+          rpeCount: Number.NaN,
+          averageRpe: Number.NaN,
+          rirCount: Number.POSITIVE_INFINITY,
+          averageRir: Number.POSITIVE_INFINITY,
+          failureCount: -1,
+        },
+      }));
+
+      expect(getSignal(summary.signals, "strength").status).toBe("unknown");
+      expect(getSignal(summary.signals, "volume").status).toBe("unknown");
+      expect(getSignal(summary.signals, "consistency").status).toBe("unknown");
+      expect(getSignal(summary.signals, "effort").status).toBe("unknown");
+      expectNoUnsafeNumbers(summary);
+    });
+
+    it("keeps deterministic output ordering", () => {
+      const first = buildGrowthSignals(buildInput());
+      const second = buildGrowthSignals(buildInput());
+
+      expect(second).toEqual(first);
+      expect(first.signals.map((signal) => signal.id)).toEqual([
+        "strength",
+        "volume",
+        "consistency",
+        "effort",
+        "exercise_progress",
+      ]);
+    });
+
+    it("does not mutate input", () => {
+      const input = buildInput();
+      const original = JSON.parse(JSON.stringify(input));
+
+      buildGrowthSignals(input);
+
+      expect(input).toEqual(original);
+    });
+
+    it("does not call external AI or API side effects", () => {
+      const originalFetch = globalThis.fetch;
+      const fetchMock = jest.fn();
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        value: fetchMock,
+      });
+
+      try {
+        buildGrowthSignals(buildInput());
+
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(globalThis, "fetch", {
+          configurable: true,
+          value: originalFetch,
+        });
+      }
+    });
+  });
+});

--- a/shared/utils/growthSignals.ts
+++ b/shared/utils/growthSignals.ts
@@ -1,0 +1,436 @@
+export type GrowthSignalStatus = "positive" | "neutral" | "watch" | "unknown";
+
+export type GrowthSignal = {
+  id: string;
+  label: string;
+  status: GrowthSignalStatus;
+  headline: string;
+  detail: string;
+  evidence: string[];
+  nextFocus: string | null;
+};
+
+export type GrowthSignalsSummary = {
+  rangeStart: string;
+  rangeEnd: string;
+  signals: GrowthSignal[];
+  dataQualityNotes: string[];
+};
+
+export type GrowthSignalsBig3Input = {
+  lift: string;
+  latestEstimatedOneRepMax: number | null;
+  maxEstimatedOneRepMax: number | null;
+  trendPointCount: number;
+};
+
+export type GrowthSignalsMuscleGroupInput = {
+  muscle: string;
+  totalSets: number;
+  totalVolumeLoad: number;
+};
+
+export type GrowthSignalsEffortInput = {
+  totalSetCount: number;
+  effortLoggedSetCount: number;
+  rpeCount: number;
+  averageRpe: number | null;
+  rirCount: number;
+  averageRir: number | null;
+  failureCount: number;
+};
+
+export type BuildGrowthSignalsInput = {
+  rangeStart: string;
+  rangeEnd: string;
+  totalNotes: number;
+  totalSets: number;
+  big3: GrowthSignalsBig3Input[];
+  muscleGroups: GrowthSignalsMuscleGroupInput[];
+  effort: GrowthSignalsEffortInput;
+  dataQualityNotes?: string[];
+};
+
+const NO_NOTES_NOTE = "No workout notes found in this range.";
+const NO_SETS_NOTE = "No normalized sets found in this range.";
+const NO_BIG3_NOTE = "No BIG3 trend data found in this range.";
+const NO_MUSCLE_NOTE = "No muscle group volume data found in this range.";
+const NO_EFFORT_NOTE = "No effort data logged in this range.";
+
+const isFiniteNumber = (value: number | null | undefined): value is number => (
+  typeof value === "number" && Number.isFinite(value)
+);
+
+const toNonNegativeNumber = (value: number | null | undefined): number => (
+  isFiniteNumber(value) && value >= 0 ? value : 0
+);
+
+const toCount = (value: number | null | undefined): number => (
+  Math.floor(toNonNegativeNumber(value))
+);
+
+const toFiniteNumberOrNull = (value: number | null | undefined): number | null => (
+  isFiniteNumber(value) ? value : null
+);
+
+const formatNumber = (value: number): string => (
+  new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(value)
+);
+
+const formatLift = (lift: string): string => {
+  switch (lift) {
+    case "bench":
+      return "Bench Press";
+    case "deadlift":
+      return "Deadlift";
+    case "squat":
+      return "Squat";
+    default:
+      return lift;
+  }
+};
+
+const uniqueStrings = (items: string[]): string[] => Array.from(new Set(items));
+
+const buildDataQualityNotes = ({
+  totalNotes,
+  totalSets,
+  big3,
+  muscleGroups,
+  effort,
+  inputNotes,
+}: {
+  totalNotes: number;
+  totalSets: number;
+  big3: GrowthSignalsBig3Input[];
+  muscleGroups: GrowthSignalsMuscleGroupInput[];
+  effort: GrowthSignalsEffortInput;
+  inputNotes?: string[];
+}): string[] => {
+  const notes = Array.isArray(inputNotes)
+    ? inputNotes.filter((note) => typeof note === "string")
+    : [];
+
+  if (totalNotes === 0) {
+    notes.push(NO_NOTES_NOTE);
+  }
+
+  if (totalSets === 0) {
+    notes.push(NO_SETS_NOTE);
+  }
+
+  if (big3.length === 0 || big3.every((summary) => summary.trendPointCount === 0)) {
+    notes.push(NO_BIG3_NOTE);
+  }
+
+  if (muscleGroups.length === 0) {
+    notes.push(NO_MUSCLE_NOTE);
+  }
+
+  if (effort.effortLoggedSetCount === 0) {
+    notes.push(NO_EFFORT_NOTE);
+  }
+
+  return uniqueStrings(notes);
+};
+
+const sanitizeBig3 = (
+  big3: GrowthSignalsBig3Input[]
+): GrowthSignalsBig3Input[] => {
+  if (!Array.isArray(big3)) {
+    return [];
+  }
+
+  return big3.map((summary) => ({
+    lift: typeof summary.lift === "string" ? summary.lift : "",
+    latestEstimatedOneRepMax: toFiniteNumberOrNull(summary.latestEstimatedOneRepMax),
+    maxEstimatedOneRepMax: toFiniteNumberOrNull(summary.maxEstimatedOneRepMax),
+    trendPointCount: toCount(summary.trendPointCount),
+  }));
+};
+
+const sanitizeMuscleGroups = (
+  muscleGroups: GrowthSignalsMuscleGroupInput[]
+): GrowthSignalsMuscleGroupInput[] => {
+  if (!Array.isArray(muscleGroups)) {
+    return [];
+  }
+
+  return muscleGroups
+    .map((group) => ({
+      muscle: typeof group.muscle === "string" ? group.muscle.trim() : "",
+      totalSets: toNonNegativeNumber(group.totalSets),
+      totalVolumeLoad: toNonNegativeNumber(group.totalVolumeLoad),
+    }))
+    .filter((group) => (
+      group.muscle !== "" && (group.totalSets > 0 || group.totalVolumeLoad > 0)
+    ))
+    .sort((a, b) => {
+      const setCompare = b.totalSets - a.totalSets;
+      return setCompare !== 0 ? setCompare : a.muscle.localeCompare(b.muscle);
+    });
+};
+
+const sanitizeEffort = (effort: GrowthSignalsEffortInput): GrowthSignalsEffortInput => ({
+  totalSetCount: toCount(effort?.totalSetCount),
+  effortLoggedSetCount: toCount(effort?.effortLoggedSetCount),
+  rpeCount: toCount(effort?.rpeCount),
+  averageRpe: toFiniteNumberOrNull(effort?.averageRpe),
+  rirCount: toCount(effort?.rirCount),
+  averageRir: toFiniteNumberOrNull(effort?.averageRir),
+  failureCount: toCount(effort?.failureCount),
+});
+
+const buildStrengthSignal = (big3: GrowthSignalsBig3Input[]): GrowthSignal => {
+  const trendPointCount = big3.reduce((total, summary) => (
+    total + summary.trendPointCount
+  ), 0);
+
+  if (trendPointCount === 0) {
+    return {
+      id: "strength",
+      label: "Strength",
+      status: "unknown",
+      headline: "Strength signal unavailable",
+      detail: "No BIG3 estimated 1RM trend points were found in this range.",
+      evidence: [],
+      nextFocus: "Log squat, bench, or deadlift top sets if strength tracking matters.",
+    };
+  }
+
+  const byMax = [...big3]
+    .filter((summary) => isFiniteNumber(summary.maxEstimatedOneRepMax))
+    .sort((a, b) => {
+      const valueCompare = (b.maxEstimatedOneRepMax ?? 0)
+        - (a.maxEstimatedOneRepMax ?? 0);
+      return valueCompare !== 0
+        ? valueCompare
+        : formatLift(a.lift).localeCompare(formatLift(b.lift));
+    });
+  const top = byMax[0] ?? big3.find((summary) => summary.trendPointCount > 0) ?? null;
+  const evidence = [`BIG3 trend points: ${trendPointCount}.`];
+
+  if (top && isFiniteNumber(top.maxEstimatedOneRepMax)) {
+    evidence.push(
+      `${formatLift(top.lift)} max estimated 1RM: ${formatNumber(top.maxEstimatedOneRepMax)}.`
+    );
+  }
+
+  if (top && isFiniteNumber(top.latestEstimatedOneRepMax)) {
+    evidence.push(
+      `${formatLift(top.lift)} latest estimated 1RM: ${formatNumber(top.latestEstimatedOneRepMax)}.`
+    );
+  }
+
+  return {
+    id: "strength",
+    label: "Strength",
+    status: "neutral",
+    headline: "Strength data is available",
+    detail: "BIG3 trend data exists, but previous range comparison is not connected yet.",
+    evidence,
+    nextFocus: "Compare these top lift signals with the next range once previous-range logic exists.",
+  };
+};
+
+const buildVolumeSignal = (muscleGroups: GrowthSignalsMuscleGroupInput[]): GrowthSignal => {
+  if (muscleGroups.length === 0) {
+    return {
+      id: "volume",
+      label: "Volume",
+      status: "unknown",
+      headline: "Volume signal unavailable",
+      detail: "No muscle group volume data was found in this range.",
+      evidence: [],
+      nextFocus: "Log exercises that match metadata so muscle group volume can be calculated.",
+    };
+  }
+
+  const top = muscleGroups[0];
+  const second = muscleGroups[1] ?? null;
+  const hasImbalance = Boolean(second && second.totalSets > 0 && top.totalSets >= second.totalSets * 3);
+  const evidence = [
+    `${top.muscle}: ${formatNumber(top.totalSets)} sets.`,
+  ];
+
+  if (top.totalVolumeLoad > 0) {
+    evidence.push(`${top.muscle} volume load: ${formatNumber(top.totalVolumeLoad)}.`);
+  }
+
+  if (second) {
+    evidence.push(`${second.muscle}: ${formatNumber(second.totalSets)} sets.`);
+  }
+
+  return {
+    id: "volume",
+    label: "Volume",
+    status: hasImbalance ? "watch" : "neutral",
+    headline: hasImbalance ? "Volume may be concentrated" : "Volume data is available",
+    detail: hasImbalance
+      ? "The top muscle group has at least 3x the sets of the next muscle group."
+      : "Muscle group volume exists for this range; previous range comparison is not connected yet.",
+    evidence,
+    nextFocus: hasImbalance
+      ? "Review whether this muscle group emphasis matches your plan."
+      : "Review volume balance across muscle groups.",
+  };
+};
+
+const buildConsistencySignal = ({
+  totalNotes,
+  totalSets,
+}: {
+  totalNotes: number;
+  totalSets: number;
+}): GrowthSignal => {
+  const evidence = [
+    `Workout notes: ${formatNumber(totalNotes)}.`,
+    `Normalized sets: ${formatNumber(totalSets)}.`,
+  ];
+
+  if (totalNotes === 0 || totalSets === 0) {
+    return {
+      id: "consistency",
+      label: "Consistency",
+      status: "unknown",
+      headline: "Consistency signal unavailable",
+      detail: "No usable notes or normalized sets were found in this range.",
+      evidence,
+      nextFocus: "Log workouts consistently to unlock trend signals.",
+    };
+  }
+
+  if (totalNotes <= 1 || totalSets < 5) {
+    return {
+      id: "consistency",
+      label: "Consistency",
+      status: "watch",
+      headline: "Consistency data is sparse",
+      detail: "This range has limited logged training, so growth signals may be less reliable.",
+      evidence,
+      nextFocus: "Keep logging sessions so the next range has more context.",
+    };
+  }
+
+  return {
+    id: "consistency",
+    label: "Consistency",
+    status: "neutral",
+    headline: "Consistency data is available",
+    detail: "This range has enough logged notes and sets for basic analytics.",
+    evidence,
+    nextFocus: "Keep the logging habit steady across future ranges.",
+  };
+};
+
+const buildEffortSignal = (effort: GrowthSignalsEffortInput): GrowthSignal => {
+  const {
+    totalSetCount,
+    effortLoggedSetCount,
+    averageRpe,
+    averageRir,
+    failureCount,
+  } = effort;
+
+  if (totalSetCount === 0 || effortLoggedSetCount === 0) {
+    return {
+      id: "effort",
+      label: "Effort",
+      status: "unknown",
+      headline: "Effort signal unavailable",
+      detail: "No RPE, RIR, or failure data was logged in this range.",
+      evidence: [`Effort coverage: 0 / ${formatNumber(totalSetCount)} sets.`],
+      nextFocus: "Log optional RPE/RIR or failure values when useful.",
+    };
+  }
+
+  const coverage = effortLoggedSetCount / totalSetCount;
+  const failureRatio = totalSetCount > 0 ? failureCount / totalSetCount : 0;
+  const isLowCoverage = coverage < 0.25;
+  const isHighFailure = failureRatio >= 0.2;
+  const evidence = [
+    `Effort coverage: ${formatNumber(effortLoggedSetCount)} / ${formatNumber(totalSetCount)} sets (${formatNumber(coverage * 100)}%).`,
+  ];
+
+  if (isFiniteNumber(averageRpe)) {
+    evidence.push(`Average RPE: ${formatNumber(averageRpe)}.`);
+  }
+
+  if (isFiniteNumber(averageRir)) {
+    evidence.push(`Average RIR: ${formatNumber(averageRir)}.`);
+  }
+
+  evidence.push(`Failure sets: ${formatNumber(failureCount)}.`);
+
+  return {
+    id: "effort",
+    label: "Effort",
+    status: isLowCoverage || isHighFailure ? "watch" : "neutral",
+    headline: isLowCoverage
+      ? "Effort data is sparse"
+      : isHighFailure
+        ? "Failure sets are worth watching"
+        : "Effort data is available",
+    detail: isLowCoverage
+      ? "Effort coverage is below 25%, so intensity interpretation is uncertain."
+      : isHighFailure
+        ? "At least 20% of sets were marked as failure in this range."
+        : "Logged effort data is available; missing values are treated as unknown.",
+    evidence,
+    nextFocus: isLowCoverage
+      ? "Log RPE/RIR on more sets if effort tracking matters."
+      : "Review effort alongside volume and top sets.",
+  };
+};
+
+const buildExerciseProgressSignal = (): GrowthSignal => ({
+  id: "exercise_progress",
+  label: "Exercise Progress",
+  status: "unknown",
+  headline: "Exercise progress signal not connected yet",
+  detail: "Selected exercise trend data is not connected to Growth Signals yet.",
+  evidence: [],
+  nextFocus: "Use the exercise trend selector to review raw and canonical exercise progress.",
+});
+
+export const buildGrowthSignals = ({
+  rangeStart,
+  rangeEnd,
+  totalNotes,
+  totalSets,
+  big3,
+  muscleGroups,
+  effort,
+  dataQualityNotes,
+}: BuildGrowthSignalsInput): GrowthSignalsSummary => {
+  const safeTotalNotes = toCount(totalNotes);
+  const safeTotalSets = toCount(totalSets);
+  const safeBig3 = sanitizeBig3(big3);
+  const safeMuscleGroups = sanitizeMuscleGroups(muscleGroups);
+  const safeEffort = sanitizeEffort(effort);
+
+  return {
+    rangeStart,
+    rangeEnd,
+    signals: [
+      buildStrengthSignal(safeBig3),
+      buildVolumeSignal(safeMuscleGroups),
+      buildConsistencySignal({
+        totalNotes: safeTotalNotes,
+        totalSets: safeTotalSets,
+      }),
+      buildEffortSignal(safeEffort),
+      buildExerciseProgressSignal(),
+    ],
+    dataQualityNotes: buildDataQualityNotes({
+      totalNotes: safeTotalNotes,
+      totalSets: safeTotalSets,
+      big3: safeBig3,
+      muscleGroups: safeMuscleGroups,
+      effort: safeEffort,
+      inputNotes: dataQualityNotes,
+    }),
+  };
+};


### PR DESCRIPTION
## Summary
- Added shared Growth Signals helper
- Added `buildGrowthSignals`
- Generates deterministic current-range signals in fixed order:
  - strength
  - volume
  - consistency
  - effort
  - exercise_progress
- Added signal statuses:
  - positive
  - neutral
  - watch
  - unknown
- Added data quality note generation and deduplication
- Added tests for full data, sparse data, strength, volume, consistency, effort, invalid values, deterministic ordering, and non-mutation
- Updated verification docs

## Verification
- `npm test` passed
  - 27 test suites passed
  - 298 tests passed
- `npm run build --prefix backend` passed
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No UI changes
- No API changes
- No DB changes
- No backend service changes
- No external AI API integration
- No API keys or env changes
- No provider SDK added