### PR TITLE
Add analytics growth signals card

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -53,6 +53,8 @@ GitHub Actions runs the same baseline on push and pull request:
 - Weekly summary response validation safely validates structured weekly summary responses before future AI rendering.
 - Shared Growth Signals helper tests are included in `npm test` and CI.
 - Growth Signals derive deterministic analytics signals without calling an external AI API.
+- Analytics displays Growth Signals from deterministic shared helper output.
+- Growth Signals are shown without calling an external AI API.
 - Frontend note set types allow optional `rpe`, `rir`, and `failure` fields.
 - Note input UI can optionally capture set-level `rpe`, `rir`, and `failure` from an advanced effort row.
 - Existing `weight` / `reps` / `rest` input remains the primary note entry flow.
@@ -85,7 +87,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add Analytics Growth Signals card, Growth Signals integration into Weekly Summary input if useful, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, optional weekly summary persistence/cache design, and external AI integration only after core analytics signals and the mocked frontend/backend flow are stable.
+- Add Growth Signals integration into Weekly Summary input if useful, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, optional weekly summary persistence/cache design, and external AI integration only after core analytics signals and the mocked frontend/backend flow are stable.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/components/GrowthSignalsSection.tsx
+++ b/frontend/features/analytics/components/GrowthSignalsSection.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import {
+  Badge,
+  Box,
+  Heading,
+  List,
+  ListItem,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import type {
+  GrowthSignal,
+  GrowthSignalStatus,
+  GrowthSignalsSummary,
+} from "../../../../shared/utils/growthSignals";
+
+type GrowthSignalsSectionProps = {
+  summary: GrowthSignalsSummary;
+};
+
+const statusColorScheme: Record<GrowthSignalStatus, string> = {
+  positive: "green",
+  neutral: "blue",
+  watch: "orange",
+  unknown: "gray",
+};
+
+const GrowthSignalCard: React.FC<{ signal: GrowthSignal }> = ({ signal }) => {
+  const evidenceItems = signal.evidence.slice(0, 3);
+
+  return (
+    <Box bg="gray.50" borderRadius="6px" p={4}>
+      <Stack spacing={3}>
+        <Stack
+          align={{ base: "flex-start", sm: "center" }}
+          direction={{ base: "column", sm: "row" }}
+          justify="space-between"
+          gap={2}
+        >
+          <Heading as="h3" size="xs" color="gray.800">
+            {signal.label}
+          </Heading>
+          <Badge colorScheme={statusColorScheme[signal.status]}>
+            {signal.status}
+          </Badge>
+        </Stack>
+
+        <Box>
+          <Text fontSize="sm" fontWeight="semibold" color="gray.800">
+            {signal.headline}
+          </Text>
+          <Text mt={1} fontSize="sm" color="gray.600">
+            {signal.detail}
+          </Text>
+        </Box>
+
+        <Box>
+          <Text mb={1} fontSize="xs" fontWeight="semibold" color="gray.600">
+            Evidence
+          </Text>
+          {evidenceItems.length > 0 ? (
+            <List spacing={1}>
+              {evidenceItems.map((item, index) => (
+                <ListItem
+                  key={`${signal.id}-evidence-${index}`}
+                  fontSize="sm"
+                  color="gray.700"
+                >
+                  {item}
+                </ListItem>
+              ))}
+            </List>
+          ) : (
+            <Text fontSize="sm" color="gray.500">
+              No evidence yet.
+            </Text>
+          )}
+        </Box>
+
+        {signal.nextFocus && (
+          <Box borderTop="1px solid" borderColor="gray.200" pt={2}>
+            <Text mb={1} fontSize="xs" fontWeight="semibold" color="gray.600">
+              Watch next
+            </Text>
+            <Text fontSize="sm" color="gray.700">
+              {signal.nextFocus}
+            </Text>
+          </Box>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+const GrowthSignalsSection: React.FC<GrowthSignalsSectionProps> = ({ summary }) => (
+  <Box
+    as="section"
+    aria-labelledby="growth-signals-heading"
+    border="1px solid"
+    borderColor="gray.200"
+    borderRadius="6px"
+    bg="white"
+    p={{ base: 4, md: 5 }}
+  >
+    <Stack spacing={4}>
+      <Box>
+        <Heading id="growth-signals-heading" as="h2" size="md">
+          Growth Signals
+        </Heading>
+        <Text mt={1} fontSize="sm" color="gray.600">
+          Deterministic signals from your logged training data.
+        </Text>
+      </Box>
+
+      <SimpleGrid columns={{ base: 1, md: 2, xl: 3 }} spacing={4}>
+        {summary.signals.map((signal) => (
+          <GrowthSignalCard key={signal.id} signal={signal} />
+        ))}
+      </SimpleGrid>
+
+      {summary.dataQualityNotes.length > 0 && (
+        <Box>
+          <Heading as="h3" size="xs" mb={2} color="gray.700">
+            Data Quality
+          </Heading>
+          <List spacing={1}>
+            {summary.dataQualityNotes.map((note, index) => (
+              <ListItem key={`growth-signal-note-${index}`} fontSize="sm" color="gray.600">
+                {note}
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+      )}
+    </Stack>
+  </Box>
+);
+
+export default GrowthSignalsSection;

--- a/frontend/features/analytics/pages/AnalyticsPage.tsx
+++ b/frontend/features/analytics/pages/AnalyticsPage.tsx
@@ -33,6 +33,7 @@ import { normalizeWorkoutSets } from "../../../../shared/utils/normalizeWorkoutS
 import {
   buildRuleBasedWeeklySummary,
 } from "../../../../shared/utils/ruleBasedWeeklySummary";
+import { buildGrowthSignals } from "../../../../shared/utils/growthSignals";
 import { summarizeSetEffort } from "../../../../shared/utils/effortAnalytics";
 import {
   toBig3EstimatedOneRepMaxSeries,
@@ -53,6 +54,7 @@ import AnalyticsRangeFilter, {
 import Big3SummarySection from "../components/Big3SummarySection";
 import EffortSummarySection from "../components/EffortSummarySection";
 import ExerciseTrendSection from "../components/ExerciseTrendSection";
+import GrowthSignalsSection from "../components/GrowthSignalsSection";
 import MuscleGroupSummarySection from "../components/MuscleGroupSummarySection";
 import WeeklySummaryPreviewSection from "../components/WeeklySummaryPreviewSection";
 
@@ -143,6 +145,19 @@ const AnalyticsPage: React.FC = () => {
   );
   const weeklySummary = useMemo(
     () => buildRuleBasedWeeklySummary(weeklySummaryInput),
+    [weeklySummaryInput]
+  );
+  const growthSignalsSummary = useMemo(
+    () => buildGrowthSignals({
+      rangeStart: weeklySummaryInput.rangeStart,
+      rangeEnd: weeklySummaryInput.rangeEnd,
+      totalNotes: weeklySummaryInput.totalNotes,
+      totalSets: weeklySummaryInput.totalSets,
+      big3: weeklySummaryInput.big3,
+      muscleGroups: weeklySummaryInput.muscleGroups,
+      effort: weeklySummaryInput.effort,
+      dataQualityNotes: weeklySummaryInput.dataQualityNotes,
+    }),
     [weeklySummaryInput]
   );
 
@@ -288,18 +303,23 @@ const AnalyticsPage: React.FC = () => {
         )}
 
         {status === "success" && (
-          <Box mb={6}>
-            <WeeklySummaryPreviewSection
-              summary={weeklySummary}
-              rangeStart={dateRange.start}
-              rangeEnd={dateRange.end}
-              generatedResponse={generatedWeeklySummary}
-              generationError={weeklySummaryError}
-              isGenerating={isGeneratingWeeklySummary}
-              canGenerate={status === "success"}
-              onGenerate={handleGenerateWeeklySummary}
-            />
-          </Box>
+          <>
+            <Box mb={6}>
+              <WeeklySummaryPreviewSection
+                summary={weeklySummary}
+                rangeStart={dateRange.start}
+                rangeEnd={dateRange.end}
+                generatedResponse={generatedWeeklySummary}
+                generationError={weeklySummaryError}
+                isGenerating={isGeneratingWeeklySummary}
+                canGenerate={status === "success"}
+                onGenerate={handleGenerateWeeklySummary}
+              />
+            </Box>
+            <Box mb={6}>
+              <GrowthSignalsSection summary={growthSignalsSummary} />
+            </Box>
+          </>
         )}
 
         {status === "success" && !hasAnalyticsData && (


### PR DESCRIPTION
## Summary
- Added `GrowthSignalsSection`
- Connected `buildGrowthSignals` to the Analytics page
- Displays strength, volume, consistency, effort, and exercise progress signals
- Shows status badges, headline, detail, evidence, and next focus
- Places Growth Signals near Weekly Summary and before the Analytics tabs
- Keeps existing Weekly Summary, Generate AI summary, charts, tabs, and range-change behavior intact
- Updated verification docs

## Verification
- `npm test` passed
  - 27 test suites passed
  - 298 tests passed
- `npm run build --prefix backend` passed
  - 24 files syntax checked
- `npm run lint --prefix frontend` passed
- `npm run build --prefix frontend` passed
- No new warnings were observed except the existing Google Fonts warning
- Dev server check: `/analytics` returned `200 OK`

## Package changes
- No package changes
- No package-lock changes
- No new dependencies

## Notes
- No API changes
- No DB changes
- No backend service changes
- No external AI API integration
- No API keys or env changes
- No provider SDK added
- No component test was added; existing Growth Signals helper tests plus frontend lint/build cover this UI connection