### PR TITLE
Add growth signals to weekly summary input

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -45,8 +45,10 @@ GitHub Actions runs the same baseline on push and pull request:
 - Shared effort analytics summary tests are included in `npm test` and CI.
 - Shared weekly summary input builder tests are included in `npm test` and CI.
 - Weekly summary input builder prepares deterministic aggregate data for future AI/rule-based summaries without calling an AI API.
+- Weekly summary input includes deterministic Growth Signals for future rule-based and AI summaries.
 - Shared rule-based weekly summary tests are included in `npm test` and CI.
 - Analytics displays a deterministic rule-based weekly summary preview without calling an AI API.
+- Rule-based weekly summary can use Growth Signals without calling an external AI API.
 - Shared weekly summary prompt builder tests are included in `npm test` and CI.
 - Weekly summary prompt builder creates provider-neutral prompt payloads without calling an external AI API.
 - Shared weekly summary response validation tests are included in `npm test` and CI.
@@ -87,7 +89,7 @@ GitHub Actions runs the same baseline on push and pull request:
 ## Test Candidates
 
 - Expand coverage for `shared/utils/calendarUtils.ts` and `shared/utils/validationUtils.ts`.
-- Add Growth Signals integration into Weekly Summary input if useful, DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, optional weekly summary persistence/cache design, and external AI integration only after core analytics signals and the mocked frontend/backend flow are stable.
+- Add DB-backed/custom exercise catalog exploration, expanded effort trend charts if needed, optional weekly summary persistence/cache design, and external AI integration only after core analytics signals and the mocked frontend/backend flow are stable.
 - Expand API client tests for retry limits and non-401 error paths.
 - Expand route/service tests for notes and auth Supabase success/error paths.
 - Resolve or document the remaining Google Fonts download warning if the build environment cannot reach Google Fonts.

--- a/frontend/features/analytics/api/__tests__/weeklySummaryApi.spec.ts
+++ b/frontend/features/analytics/api/__tests__/weeklySummaryApi.spec.ts
@@ -27,6 +27,22 @@ const createRequest = () => ({
       averageRir: 1.5,
       failureCount: 2,
     },
+    growthSignals: {
+      rangeStart: "2026-06-01",
+      rangeEnd: "2026-06-07",
+      signals: [
+        {
+          id: "effort",
+          label: "Effort",
+          status: "neutral" as const,
+          headline: "Effort data is available",
+          detail: "Logged effort data is available.",
+          evidence: ["Effort coverage: 12 / 42 sets."],
+          nextFocus: "Review effort alongside volume and top sets.",
+        },
+      ],
+      dataQualityNotes: [],
+    },
     dataQualityNotes: [],
   },
 });

--- a/shared/utils/__tests__/ruleBasedWeeklySummary.spec.ts
+++ b/shared/utils/__tests__/ruleBasedWeeklySummary.spec.ts
@@ -2,57 +2,74 @@ import {
   buildRuleBasedWeeklySummary,
   type RuleBasedWeeklySummary,
 } from "../ruleBasedWeeklySummary";
+import { buildGrowthSignals } from "../growthSignals";
 import type { WeeklySummaryInput } from "../weeklySummaryInput";
 
-const buildInput = (overrides: Partial<WeeklySummaryInput> = {}): WeeklySummaryInput => ({
-  rangeStart: "2026-06-01",
-  rangeEnd: "2026-06-07",
-  totalNotes: 3,
-  totalSets: 12,
-  big3: [
-    {
-      lift: "squat",
-      latestEstimatedOneRepMax: 152.5,
-      maxEstimatedOneRepMax: 155,
-      trendPointCount: 2,
+const buildInput = (overrides: Partial<WeeklySummaryInput> = {}): WeeklySummaryInput => {
+  const input = {
+    rangeStart: "2026-06-01",
+    rangeEnd: "2026-06-07",
+    totalNotes: 3,
+    totalSets: 12,
+    big3: [
+      {
+        lift: "squat",
+        latestEstimatedOneRepMax: 152.5,
+        maxEstimatedOneRepMax: 155,
+        trendPointCount: 2,
+      },
+      {
+        lift: "bench",
+        latestEstimatedOneRepMax: 122.5,
+        maxEstimatedOneRepMax: 125,
+        trendPointCount: 3,
+      },
+      {
+        lift: "deadlift",
+        latestEstimatedOneRepMax: 180,
+        maxEstimatedOneRepMax: 180,
+        trendPointCount: 1,
+      },
+    ],
+    muscleGroups: [
+      {
+        muscle: "chest",
+        totalSets: 10,
+        totalVolumeLoad: 2400,
+      },
+      {
+        muscle: "back",
+        totalSets: 8,
+        totalVolumeLoad: 2100,
+      },
+    ],
+    effort: {
+      totalSetCount: 12,
+      effortLoggedSetCount: 8,
+      rpeCount: 6,
+      averageRpe: 8.25,
+      rirCount: 4,
+      averageRir: 1.5,
+      failureCount: 2,
     },
-    {
-      lift: "bench",
-      latestEstimatedOneRepMax: 122.5,
-      maxEstimatedOneRepMax: 125,
-      trendPointCount: 3,
-    },
-    {
-      lift: "deadlift",
-      latestEstimatedOneRepMax: 180,
-      maxEstimatedOneRepMax: 180,
-      trendPointCount: 1,
-    },
-  ],
-  muscleGroups: [
-    {
-      muscle: "chest",
-      totalSets: 10,
-      totalVolumeLoad: 2400,
-    },
-    {
-      muscle: "back",
-      totalSets: 8,
-      totalVolumeLoad: 2100,
-    },
-  ],
-  effort: {
-    totalSetCount: 12,
-    effortLoggedSetCount: 8,
-    rpeCount: 6,
-    averageRpe: 8.25,
-    rirCount: 4,
-    averageRir: 1.5,
-    failureCount: 2,
-  },
-  dataQualityNotes: [],
-  ...overrides,
-});
+    dataQualityNotes: [],
+    ...overrides,
+  };
+
+  return {
+    ...input,
+    growthSignals: overrides.growthSignals ?? buildGrowthSignals({
+      rangeStart: input.rangeStart,
+      rangeEnd: input.rangeEnd,
+      totalNotes: input.totalNotes,
+      totalSets: input.totalSets,
+      big3: input.big3,
+      muscleGroups: input.muscleGroups,
+      effort: input.effort,
+      dataQualityNotes: input.dataQualityNotes,
+    }),
+  };
+};
 
 const expectNoUnsafeNumbers = (summary: RuleBasedWeeklySummary) => {
   const serialized = JSON.stringify(summary);
@@ -182,6 +199,94 @@ describe("ruleBasedWeeklySummary", () => {
         "Effort data is sparse, so intensity trends may be less reliable."
       );
       expect(summary.summary).toContain("effort was logged for 2 / 12 sets");
+    });
+
+    it("adds watch Growth Signals to concerns", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          growthSignals: {
+            rangeStart: "2026-06-01",
+            rangeEnd: "2026-06-07",
+            signals: [
+              {
+                id: "effort",
+                label: "Effort",
+                status: "watch",
+                headline: "Effort data is sparse",
+                detail: "Effort coverage is below the target range.",
+                evidence: ["Effort coverage: 2 / 12 sets."],
+                nextFocus: "Log RPE/RIR on more sets.",
+              },
+            ],
+            dataQualityNotes: [],
+          },
+        })
+      );
+
+      expect(summary.concerns).toContain("Watch effort: Effort data is sparse.");
+    });
+
+    it("adds positive Growth Signals to highlights", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          growthSignals: {
+            rangeStart: "2026-06-01",
+            rangeEnd: "2026-06-07",
+            signals: [
+              {
+                id: "strength",
+                label: "Strength",
+                status: "positive",
+                headline: "Top lift signal improved",
+                detail: "The current range is above the previous range.",
+                evidence: ["Bench Press estimated 1RM increased."],
+                nextFocus: "Watch whether the trend continues.",
+              },
+            ],
+            dataQualityNotes: [],
+          },
+        })
+      );
+
+      expect(summary.highlights).toContain(
+        "Positive strength signal: Top lift signal improved."
+      );
+    });
+
+    it("does not over-surface unknown Growth Signals", () => {
+      const summary = buildRuleBasedWeeklySummary(
+        buildInput({
+          growthSignals: {
+            rangeStart: "2026-06-01",
+            rangeEnd: "2026-06-07",
+            signals: [
+              {
+                id: "exercise_progress",
+                label: "Exercise Progress",
+                status: "unknown",
+                headline: "Exercise progress signal not connected yet",
+                detail: "Exercise trend data is not connected yet.",
+                evidence: [],
+                nextFocus: "Use the exercise trend selector.",
+              },
+            ],
+            dataQualityNotes: [],
+          },
+        })
+      );
+      const serialized = JSON.stringify(summary);
+
+      expect(serialized).not.toContain("Exercise progress signal not connected yet");
+      expect(serialized).not.toContain("Exercise Progress");
+    });
+
+    it("handles legacy weekly summary input without Growth Signals", () => {
+      const legacyInput = buildInput() as WeeklySummaryInput & {
+        growthSignals?: WeeklySummaryInput["growthSignals"];
+      };
+      delete legacyInput.growthSignals;
+
+      expect(() => buildRuleBasedWeeklySummary(legacyInput)).not.toThrow();
     });
 
     it("flags relatively frequent failure sets", () => {

--- a/shared/utils/__tests__/weeklySummaryInput.spec.ts
+++ b/shared/utils/__tests__/weeklySummaryInput.spec.ts
@@ -100,7 +100,9 @@ const buildInput = (overrides: Partial<Parameters<typeof buildWeeklySummaryInput
 describe("weeklySummaryInput", () => {
   describe("buildWeeklySummaryInput", () => {
     it("builds deterministic aggregate summary input from full data", () => {
-      expect(buildInput()).toEqual({
+      const input = buildInput();
+
+      expect(input).toEqual({
         rangeStart: "2026-06-01",
         rangeEnd: "2026-06-07",
         totalNotes: 3,
@@ -138,8 +140,75 @@ describe("weeklySummaryInput", () => {
           },
         ],
         effort: effortSummary,
+        growthSignals: expect.objectContaining({
+          rangeStart: "2026-06-01",
+          rangeEnd: "2026-06-07",
+          signals: expect.any(Array),
+          dataQualityNotes: [],
+        }),
         dataQualityNotes: [],
       });
+    });
+
+    it("includes Growth Signals in fixed order", () => {
+      const input = buildInput();
+
+      expect(input.growthSignals.signals).toHaveLength(5);
+      expect(input.growthSignals.signals.map((signal) => signal.id)).toEqual([
+        "strength",
+        "volume",
+        "consistency",
+        "effort",
+        "exercise_progress",
+      ]);
+    });
+
+    it("includes unknown Growth Signals when no data is available", () => {
+      const input = buildInput({
+        totalNotes: 0,
+        normalizedSets: [],
+        big3Summaries: [],
+        muscleRows: [],
+        effortSummary: {
+          totalSetCount: 0,
+          effortLoggedSetCount: 0,
+          rpeCount: 0,
+          averageRpe: null,
+          rirCount: 0,
+          averageRir: null,
+          failureCount: 0,
+        },
+      });
+
+      expect(input.growthSignals.signals.map((signal) => signal.status)).toEqual([
+        "unknown",
+        "unknown",
+        "unknown",
+        "unknown",
+        "unknown",
+      ]);
+      expect(input.growthSignals.dataQualityNotes).toEqual([
+        "No workout notes found in this range.",
+        "No normalized sets found in this range.",
+        "No BIG3 trend data found in this range.",
+        "No muscle group volume data found in this range.",
+        "No effort data logged in this range.",
+      ]);
+    });
+
+    it("passes data quality notes into Growth Signals", () => {
+      const input = buildInput({
+        effortSummary: {
+          ...effortSummary,
+          totalSetCount: 10,
+          effortLoggedSetCount: 2,
+        },
+      });
+
+      expect(input.dataQualityNotes).toContain("Effort data is sparse in this range.");
+      expect(input.growthSignals.dataQualityNotes).toContain(
+        "Effort data is sparse in this range."
+      );
     });
 
     it("adds a data quality note when no notes are present", () => {

--- a/shared/utils/__tests__/weeklySummaryPromptBuilder.spec.ts
+++ b/shared/utils/__tests__/weeklySummaryPromptBuilder.spec.ts
@@ -35,6 +35,22 @@ const weeklySummaryInput: WeeklySummaryInput = {
     averageRir: 1.5,
     failureCount: 2,
   },
+  growthSignals: {
+    rangeStart: "2026-06-01",
+    rangeEnd: "2026-06-07",
+    signals: [
+      {
+        id: "effort",
+        label: "Effort",
+        status: "watch",
+        headline: "Effort data is sparse",
+        detail: "Effort coverage is below the desired range.",
+        evidence: ["Effort coverage: 8 / 12 sets."],
+        nextFocus: "Keep logging RPE/RIR for better effort tracking.",
+      },
+    ],
+    dataQualityNotes: ["Effort data is sparse in this range."],
+  },
   dataQualityNotes: ["Effort data is sparse in this range."],
 };
 
@@ -117,6 +133,17 @@ describe("weeklySummaryPromptBuilder", () => {
 
     it("keeps weekly summary input as structured data", () => {
       expect(buildPayload().data).toEqual(weeklySummaryInput);
+    });
+
+    it("includes Growth Signals in prompt payload data", () => {
+      const payload = buildPayload();
+
+      expect(payload.data.growthSignals.signals).toHaveLength(1);
+      expect(payload.data.growthSignals.signals[0]).toEqual(expect.objectContaining({
+        id: "effort",
+        status: "watch",
+        headline: "Effort data is sparse",
+      }));
     });
 
     it("does not include raw note text from accidental extra input fields", () => {
@@ -217,6 +244,8 @@ describe("weeklySummaryPromptBuilder", () => {
       expect(messages[1].content).toContain('"rangeStart": "2026-06-01"');
       expect(messages[1].content).toContain('"totalSets": 12');
       expect(messages[1].content).toContain('"averageRpe": 8.1');
+      expect(messages[1].content).toContain('"growthSignals"');
+      expect(messages[1].content).toContain('"headline": "Effort data is sparse"');
     });
 
     it("does not add provider-specific fields", () => {

--- a/shared/utils/ruleBasedWeeklySummary.ts
+++ b/shared/utils/ruleBasedWeeklySummary.ts
@@ -1,6 +1,7 @@
 import type {
   EffortAnalyticsSummary,
 } from "./effortAnalytics";
+import type { GrowthSignal } from "./growthSignals";
 import type {
   WeeklySummaryBig3Input,
   WeeklySummaryInput,
@@ -75,6 +76,16 @@ const getDataQualityNotes = (input: WeeklySummaryInput): string[] => (
     ? input.dataQualityNotes.filter((note) => typeof note === "string")
     : []
 );
+
+const getGrowthSignals = (input: WeeklySummaryInput): GrowthSignal[] => {
+  const growthSignals = (
+    input as WeeklySummaryInput & {
+      growthSignals?: WeeklySummaryInput["growthSignals"] | null;
+    }
+  ).growthSignals;
+
+  return Array.isArray(growthSignals?.signals) ? growthSignals.signals : [];
+};
 
 const getTopBig3 = (
   big3: WeeklySummaryBig3Input[]
@@ -194,6 +205,15 @@ const buildHighlights = ({
   return highlights;
 };
 
+const buildGrowthSignalHighlights = (input: WeeklySummaryInput): string[] => (
+  getGrowthSignals(input)
+    .filter((signal) => signal.status === "positive")
+    .slice(0, 2)
+    .map((signal) => (
+      `Positive ${signal.label.toLowerCase()} signal: ${signal.headline}.`
+    ))
+);
+
 const buildConcerns = (input: WeeklySummaryInput, dataQualityNotes: string[]): string[] => {
   const concerns: string[] = [];
 
@@ -223,6 +243,15 @@ const buildConcerns = (input: WeeklySummaryInput, dataQualityNotes: string[]): s
 
   return concerns;
 };
+
+const buildGrowthSignalConcerns = (input: WeeklySummaryInput): string[] => (
+  getGrowthSignals(input)
+    .filter((signal) => signal.status === "watch")
+    .slice(0, 2)
+    .map((signal) => (
+      `Watch ${signal.label.toLowerCase()}: ${signal.headline}.`
+    ))
+);
 
 const buildNextWeekFocus = ({
   input,
@@ -288,12 +317,18 @@ export const buildRuleBasedWeeklySummary = (
       totalSets,
       topBig3,
     }),
-    highlights: buildHighlights({
-      input: safeInput,
-      topBig3,
-      topMuscleGroup,
-    }),
-    concerns: buildConcerns(safeInput, dataQualityNotes),
+    highlights: [
+      ...buildHighlights({
+        input: safeInput,
+        topBig3,
+        topMuscleGroup,
+      }),
+      ...buildGrowthSignalHighlights(safeInput),
+    ],
+    concerns: [
+      ...buildConcerns(safeInput, dataQualityNotes),
+      ...buildGrowthSignalConcerns(safeInput),
+    ],
     nextWeekFocus: buildNextWeekFocus({
       input: safeInput,
       totalSets,

--- a/shared/utils/weeklySummaryInput.ts
+++ b/shared/utils/weeklySummaryInput.ts
@@ -1,5 +1,9 @@
 import type { Big3TrendSummary } from "./big3Trend";
 import type { EffortAnalyticsSummary } from "./effortAnalytics";
+import {
+  buildGrowthSignals,
+  type GrowthSignalsSummary,
+} from "./growthSignals";
 import type { WeeklyMuscleGroupVolumeRow } from "./muscleGroupVolume";
 
 export type WeeklySummaryBig3Input = {
@@ -23,6 +27,7 @@ export type WeeklySummaryInput = {
   big3: WeeklySummaryBig3Input[];
   muscleGroups: WeeklySummaryMuscleGroupInput[];
   effort: EffortAnalyticsSummary;
+  growthSignals: GrowthSignalsSummary;
   dataQualityNotes: string[];
 };
 
@@ -203,6 +208,23 @@ export const buildWeeklySummaryInput = ({
   const big3 = buildBig3Input(big3Summaries);
   const muscleGroups = buildMuscleGroupInput(muscleRows);
   const effort = sanitizeEffortSummary(effortSummary);
+  const dataQualityNotes = buildDataQualityNotes({
+    totalNotes: safeTotalNotes,
+    totalSets,
+    big3,
+    muscleGroups,
+    effort,
+  });
+  const growthSignals = buildGrowthSignals({
+    rangeStart,
+    rangeEnd,
+    totalNotes: safeTotalNotes,
+    totalSets,
+    big3,
+    muscleGroups,
+    effort,
+    dataQualityNotes,
+  });
 
   return {
     rangeStart,
@@ -212,12 +234,7 @@ export const buildWeeklySummaryInput = ({
     big3,
     muscleGroups,
     effort,
-    dataQualityNotes: buildDataQualityNotes({
-      totalNotes: safeTotalNotes,
-      totalSets,
-      big3,
-      muscleGroups,
-      effort,
-    }),
+    growthSignals,
+    dataQualityNotes,
   };
 };

--- a/shared/utils/weeklySummaryPromptBuilder.ts
+++ b/shared/utils/weeklySummaryPromptBuilder.ts
@@ -1,4 +1,9 @@
 import type {
+  GrowthSignal,
+  GrowthSignalsSummary,
+  GrowthSignalStatus,
+} from "./growthSignals";
+import type {
   WeeklySummaryBig3Input,
   WeeklySummaryInput,
   WeeklySummaryMuscleGroupInput,
@@ -103,6 +108,10 @@ const toText = (value: string | null | undefined): string => (
   typeof value === "string" ? value : ""
 );
 
+const toNullableText = (value: string | null | undefined): string | null => (
+  typeof value === "string" ? value : null
+);
+
 const resolveLocale = (
   locale: WeeklySummaryPromptLocale | undefined
 ): WeeklySummaryPromptLocale => (
@@ -154,26 +163,86 @@ const sanitizeDataQualityNotes = (notes: string[]): string[] => {
   return notes.filter((note) => typeof note === "string");
 };
 
+const sanitizeGrowthSignalStatus = (
+  status: GrowthSignalStatus | undefined
+): GrowthSignalStatus => (
+  status === "positive" ||
+  status === "neutral" ||
+  status === "watch" ||
+  status === "unknown"
+    ? status
+    : "unknown"
+);
+
+const sanitizeGrowthSignalEvidence = (evidence: string[]): string[] => {
+  if (!Array.isArray(evidence)) {
+    return [];
+  }
+
+  return evidence.filter((item) => typeof item === "string");
+};
+
+const sanitizeGrowthSignals = (
+  growthSignals: GrowthSignalsSummary | undefined,
+  rangeStart: string,
+  rangeEnd: string
+): GrowthSignalsSummary => {
+  if (!growthSignals || !Array.isArray(growthSignals.signals)) {
+    return {
+      rangeStart,
+      rangeEnd,
+      signals: [],
+      dataQualityNotes: [],
+    };
+  }
+
+  return {
+    rangeStart: toText(growthSignals.rangeStart) || rangeStart,
+    rangeEnd: toText(growthSignals.rangeEnd) || rangeEnd,
+    signals: growthSignals.signals.map((signal: GrowthSignal) => ({
+      id: toText(signal.id),
+      label: toText(signal.label),
+      status: sanitizeGrowthSignalStatus(signal.status),
+      headline: toText(signal.headline),
+      detail: toText(signal.detail),
+      evidence: sanitizeGrowthSignalEvidence(signal.evidence),
+      nextFocus: toNullableText(signal.nextFocus),
+    })),
+    dataQualityNotes: sanitizeDataQualityNotes(growthSignals.dataQualityNotes),
+  };
+};
+
 const sanitizeWeeklySummaryInput = (
   input: WeeklySummaryInput
-): WeeklySummaryInput => ({
-  rangeStart: toText(input.rangeStart),
-  rangeEnd: toText(input.rangeEnd),
-  totalNotes: toNonNegativeCount(input.totalNotes),
-  totalSets: toNonNegativeCount(input.totalSets),
-  big3: sanitizeBig3(input.big3),
-  muscleGroups: sanitizeMuscleGroups(input.muscleGroups),
-  effort: {
-    totalSetCount: toNonNegativeCount(input.effort.totalSetCount),
-    effortLoggedSetCount: toNonNegativeCount(input.effort.effortLoggedSetCount),
-    rpeCount: toNonNegativeCount(input.effort.rpeCount),
-    averageRpe: toFiniteNumberOrNull(input.effort.averageRpe),
-    rirCount: toNonNegativeCount(input.effort.rirCount),
-    averageRir: toFiniteNumberOrNull(input.effort.averageRir),
-    failureCount: toNonNegativeCount(input.effort.failureCount),
-  },
-  dataQualityNotes: sanitizeDataQualityNotes(input.dataQualityNotes),
-});
+): WeeklySummaryInput => {
+  const rangeStart = toText(input.rangeStart);
+  const rangeEnd = toText(input.rangeEnd);
+  const growthSignals = (
+    input as WeeklySummaryInput & {
+      growthSignals?: GrowthSignalsSummary;
+    }
+  ).growthSignals;
+
+  return {
+    rangeStart,
+    rangeEnd,
+    totalNotes: toNonNegativeCount(input.totalNotes),
+    totalSets: toNonNegativeCount(input.totalSets),
+    big3: sanitizeBig3(input.big3),
+    muscleGroups: sanitizeMuscleGroups(input.muscleGroups),
+    effort: {
+      totalSetCount: toNonNegativeCount(input.effort.totalSetCount),
+      effortLoggedSetCount: toNonNegativeCount(input.effort.effortLoggedSetCount),
+      rpeCount: toNonNegativeCount(input.effort.rpeCount),
+      averageRpe: toFiniteNumberOrNull(input.effort.averageRpe),
+      rirCount: toNonNegativeCount(input.effort.rirCount),
+      averageRir: toFiniteNumberOrNull(input.effort.averageRir),
+      failureCount: toNonNegativeCount(input.effort.failureCount),
+    },
+    growthSignals: sanitizeGrowthSignals(growthSignals, rangeStart, rangeEnd),
+    dataQualityNotes: sanitizeDataQualityNotes(input.dataQualityNotes),
+  };
+};
 
 const buildTaskInstruction = (
   locale: WeeklySummaryPromptLocale,


### PR DESCRIPTION
## Summary

* Added Growth Signals to `WeeklySummaryInput`
* Connected `buildWeeklySummaryInput` to `buildGrowthSignals`
* Included deterministic Growth Signals in future rule-based and AI summary inputs
* Updated rule-based weekly summary to use positive and watch Growth Signals lightly
* Kept unknown Growth Signals from being over-displayed
* Confirmed prompt payload/messages include Growth Signals while preserving provider-neutral safety rules
* Updated tests and verification docs

## Verification

* `npm test` passed

  * 27 test suites passed
  * 306 tests passed
* `npm run build --prefix backend` passed
* `npm run lint --prefix frontend` passed
* `npm run build --prefix frontend` passed
* No new warnings were observed except the existing Google Fonts warning

## Package changes

* No package changes
* No package-lock changes
* No new dependencies

## Notes

* No UI changes
* No API implementation changes
* No DB changes
* No backend service changes
* No external AI API integration
* No API keys or env changes
* No provider SDK added
